### PR TITLE
Hotfix: Fixed reference block number

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -31,8 +31,10 @@ __spec_version__ = (
 
 # The validator WANDB project.
 WANDB_PROJECT = "pretraining-subnet"
+
 # The uid for this subnet.
 SUBNET_UID = 9
+
 # The root directory of this project.
 ROOT_DIR = Path(__file__).parent.parent
 
@@ -86,7 +88,6 @@ MODEL_CRITERIA_BY_BLOCK = [
             max_model_parameters=186_000_000,
             allowed_model_types=ALLOWED_MODEL_TYPES_1,
             tokenizer_identifier=TokenizerIdentifier.DISTILGPT_2,
-            evaluation_dataset=DATASET_1,
         ),
     ),
     (
@@ -98,7 +99,6 @@ MODEL_CRITERIA_BY_BLOCK = [
             max_model_parameters=772_000_000,
             allowed_model_types=ALLOWED_MODEL_TYPES_1,
             tokenizer_identifier=TokenizerIdentifier.DISTILGPT_2,
-            evaluation_dataset=DATASET_1,
         ),
     ),
     (
@@ -110,19 +110,6 @@ MODEL_CRITERIA_BY_BLOCK = [
             max_model_parameters=6_900_000_000,
             allowed_model_types=ALLOWED_MODEL_TYPES_2,
             tokenizer_identifier=TokenizerIdentifier.GPT_4_TIKTOKEN,
-            evaluation_dataset=DATASET_1,
-        ),
-    ),
-    (
-        BLOCK_FW_EDU_SCORE_2,
-        ModelCriteria(
-            sequence_length=SEQUENCE_LENGTH_2,
-            optimized=True,
-            max_model_bytes=15 * 1024 * 1024 * 1024,
-            max_model_parameters=6_900_000_000,
-            allowed_model_types=ALLOWED_MODEL_TYPES_2,
-            tokenizer_identifier=TokenizerIdentifier.GPT_4_TIKTOKEN,
-            evaluation_dataset=DATASET_2,
         ),
     ),
 ]

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -18,7 +18,7 @@ from model.data import ModelCriteria, TokenizerIdentifier
 # ---------------------------------
 
 # Release
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 
 # Validator schema version
 __validator_version__ = "2.2.2"
@@ -43,7 +43,7 @@ ROOT_DIR = Path(__file__).parent.parent
 BLOCK_7B = 2_786_061
 
 # Block at which FineWeb edu score 2 dataset is used for evaluation
-BLOCK_FW_EDU_SCORE_2 = 3_256_604
+BLOCK_FW_EDU_SCORE_2 = 3_307_004
 
 # FIXING MODEL CRITERIA
 

--- a/model/data.py
+++ b/model/data.py
@@ -99,6 +99,4 @@ class ModelCriteria:
 
     # Tokenizer to use.
     tokenizer_identifier: TokenizerIdentifier
-
-    # Evaluation dataset
-    evaluation_dataset: str
+    

--- a/model/storage/chain/chain_model_metadata_store.py
+++ b/model/storage/chain/chain_model_metadata_store.py
@@ -47,7 +47,7 @@ class ChainModelMetadataStore(ModelMetadataStore):
             bt.extrinsics.serving.get_metadata, self.subtensor, self.subnet_uid, hotkey
         )
 
-        metadata = utils.run_in_subprocess(partial, 60)
+        metadata = utils.run_in_subprocess(partial, 180)
 
         if not metadata:
             return None

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -545,7 +545,7 @@ class Validator:
         dataloader_old = SubsetDataLoader(
                 batch_size=constants.batch_size,
                 sequence_length=constants.SEQUENCE_LENGTH_1,
-                num_pages=self.config.pages_per_eval,
+                num_pages=self.config.pages_per_eval, # The pages will be sampled inside the object
                 tokenizer=tokenizer_old,
             )
         
@@ -561,9 +561,12 @@ class Validator:
         dataloader_new = SubsetDataLoader(
             batch_size=constants.batch_size,
             sequence_length=constants.SEQUENCE_LENGTH_2,
-            num_pages=self.config.pages_per_eval,
+            num_pages=None, # Do not automatically generate pages. They will be manually set.
             tokenizer=tokenizer_new,
             )
+
+        # Use the same pages as for models with old tokenizers
+        dataloader_new.fetch_data_for_pages(pages=dataloader_old.pages)
         
         batches_new = list(
             dataloader_new

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -71,8 +71,6 @@ class Validator:
     def __init__(self):
         self.config = config.validator_config()
         bt.logging(config=self.config)
-        bt.logging.set_debug()
-        bt.logging.set_trace()        
 
         bt.logging.info(f"Starting validator with config: {self.config}")
 
@@ -527,13 +525,13 @@ class Validator:
         uid_to_block = defaultdict(lambda: math.inf)
 
         bt.logging.trace(f'Current block: {self.current_block}')
-        
+
         # Decide on which dataset loader class to use
         if self.current_block >= constants.BLOCK_FW_EDU_SCORE_2:
             bt.logging.trace(f'Dataset in use: {constants.DATASET_2}.')
             SubsetDataLoader = pt.dataset.SubsetFineWebEdu2Loader
         else:
-            bt.logging.trace(f'Dataset in use: {constants.DATASET_1}.')            
+            bt.logging.trace(f'Dataset in use: {constants.DATASET_1}.')
             SubsetDataLoader = pt.dataset.SubsetFalconLoader
 
         # Temporary ugliness to load the batches with both the previous tokenizer
@@ -548,12 +546,12 @@ class Validator:
                 num_pages=self.config.pages_per_eval, # The pages will be sampled inside the object
                 tokenizer=tokenizer_old,
             )
-        
+
         batches_old = list(
             dataloader_old
         )
 
-        # This is useful for logging to wandb        
+        # This is useful for logging to wandb
         pages = dataloader_old.get_page_names()
 
         ## Second tokenizer (For 7B models)
@@ -567,13 +565,13 @@ class Validator:
 
         # Use the same pages as for models with old tokenizers
         dataloader_new.fetch_data_for_pages(pages=dataloader_old.pages)
-        
+
         batches_new = list(
             dataloader_new
         )
 
         bt.logging.debug(f"Computing losses on {uids} with pages {pages}")
-        
+
         # Compute model losses on batches.
         losses_per_uid = {muid: None for muid in uids}
 
@@ -816,12 +814,12 @@ class Validator:
         """Runs the validator loop, which continuously evaluates models and sets weights."""
         while True:
             try:
-                
+
                 while (
                         (self.metagraph.block.item() - self.last_epoch)
                         < self.config.blocks_per_epoch
                 ):
-                    self.current_block = self.metagraph.block.item()                    
+                    self.current_block = self.metagraph.block.item()
                     await self.try_run_step(ttl=60 * 20)
                     await self.try_sync_metagraph(ttl=60)
                     self.save_state()

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -71,6 +71,8 @@ class Validator:
     def __init__(self):
         self.config = config.validator_config()
         bt.logging(config=self.config)
+        bt.logging.set_debug()
+        bt.logging.set_trace()        
 
         bt.logging.info(f"Starting validator with config: {self.config}")
 
@@ -93,7 +95,7 @@ class Validator:
             self.new_wandb_run()
 
         # === Running args ===
-        self.weights = torch.zeros_like(self.metagraph.S)
+        self.weights = torch.zeros_like(torch.tensor(self.metagraph.S))
         self.epoch_step = 0
         self.global_step = 0
         self.last_epoch = self.metagraph.block.item()
@@ -524,55 +526,51 @@ class Validator:
         # Default to an infinite block if we can't retrieve the metadata for the miner.
         uid_to_block = defaultdict(lambda: math.inf)
 
-        # Generate random pages for evaluation and prepare batches for each page
-        # the dataset contains >900 million pages to eval over.
-
-        old_pages = [
-            random.randint(1, pt.dataset.SubsetFalconLoader.max_pages)
-            for _ in range(self.config.pages_per_eval)
-        ]
+        bt.logging.trace(f'Current block: {self.current_block}')
+        
+        # Decide on which dataset loader class to use
+        if self.current_block >= constants.BLOCK_FW_EDU_SCORE_2:
+            bt.logging.trace(f'Dataset in use: {constants.DATASET_2}.')
+            SubsetDataLoader = pt.dataset.SubsetFineWebEdu2Loader
+        else:
+            bt.logging.trace(f'Dataset in use: {constants.DATASET_1}.')            
+            SubsetDataLoader = pt.dataset.SubsetFalconLoader
 
         # Temporary ugliness to load the batches with both the previous tokenizer
         # and the new tokenizer. batches_old can be removed once the block is newer
         # than the point we allow 7B parameter models.
-        # old_tokenizer = pt.model.get_old_tokenizer(cache_dir=self.config.model_dir)
-        # batches_old = list(
-        #     pt.dataset.SubsetFalconLoader(
-        #         batch_size=constants.batch_size,
-        #         sequence_length=constants.SEQUENCE_LENGTH_1,
-        #         pages=pages,
-        #         tokenizer=old_tokenizer,
-        #     )
-        # )
 
-        new_tokenizer = pt.model.get_tokenizer(cache_dir=self.config.model_dir)
-        old_batches = list(
-            pt.dataset.SubsetFalconLoader(
+        ## First tokenizer (Prior to 7B models)
+        tokenizer_old = pt.model.get_old_tokenizer(cache_dir=self.config.model_dir)
+        dataloader_old = SubsetDataLoader(
                 batch_size=constants.batch_size,
-                sequence_length=constants.SEQUENCE_LENGTH_2,
-                pages=old_pages,
-                tokenizer=new_tokenizer,
+                sequence_length=constants.SEQUENCE_LENGTH_1,
+                num_pages=self.config.pages_per_eval,
+                tokenizer=tokenizer_old,
             )
+        
+        batches_old = list(
+            dataloader_old
         )
 
+        # This is useful for logging to wandb        
+        pages = dataloader_old.get_page_names()
 
-        new_dataset = pt.dataset.SubsetFineWebEdu2Loader(
+        ## Second tokenizer (For 7B models)
+        tokenizer_new = pt.model.get_tokenizer(cache_dir=self.config.model_dir)
+        dataloader_new = SubsetDataLoader(
             batch_size=constants.batch_size,
             sequence_length=constants.SEQUENCE_LENGTH_2,
             num_pages=self.config.pages_per_eval,
-            tokenizer=new_tokenizer,
-        )
+            tokenizer=tokenizer_new,
+            )
         
-        new_batches = list(
-            new_dataset
+        batches_new = list(
+            dataloader_new
         )
 
-        # This is useful for logging to wandb
-        new_pages = [f'{cfg_name}_{num_rows}_{split}' for
-                     cfg_name, num_rows, split in new_dataset.pages]
+        bt.logging.debug(f"Computing losses on {uids} with pages {pages}")
         
-        # bt.logging.debug(f"Computing losses on {uids} with pages {pages}")
-
         # Compute model losses on batches.
         losses_per_uid = {muid: None for muid in uids}
 
@@ -588,8 +586,8 @@ class Validator:
                 hotkey
             )
 
-            old_losses = [math.inf for _ in range(len(old_batches))]
-            new_losses = [math.inf for _ in range(len(new_batches))]
+            # This variable should be overwritten below if the model has metadata.
+            losses = [math.inf for _ in range(len(batches_new))]
 
             if model_i_metadata != None:
                 try:
@@ -601,8 +599,6 @@ class Validator:
                     optimized = criteria.optimized
                     # Use tokenizer based on block.
                     tokenizer_identifier = criteria.tokenizer_identifier
-                    # datasets to use based on block.
-                    dataset = criteria.evaluation_dataset
 
                     # Get the model locally and evaluate its loss.
                     model_i = None
@@ -616,18 +612,17 @@ class Validator:
                     with compute_loss_perf.sample():
                         # Run each computation in a subprocess so that the GPU is reset between each model.
                         batches_to_use = None
+
                         # Keeping identical behavior of getting this from eos token id.
                         # Currently we set pad token = eos token but not the ids on the get tokenizer methods.
-                        pad_token_id = new_tokenizer.eos_token_id
+                        pad_token_id = None
 
-                        if dataset == constants.DATASET_1:
-                            batches_to_use = old_batches
-                            losses = old_losses
-                            pages_to_use = old_pages
+                        if tokenizer_identifier == TokenizerIdentifier.DISTILGPT_2:
+                            batches_to_use = batches_old
+                            pad_token_id = tokenizer_old.eos_token_id
                         else:
-                            batches_to_use = new_batches
-                            losses = new_losses
-                            pages_to_use = new_pages
+                            batches_to_use = batches_new
+                            pad_token_id = tokenizer_new.eos_token_id
 
                         losses = utils.run_in_subprocess(
                             functools.partial(
@@ -658,7 +653,7 @@ class Validator:
 
         # Compute wins and win rates per uid.
         wins, win_rate = pt.validation.compute_wins(
-            uids, losses_per_uid, batches_to_use, uid_to_block
+            uids, losses_per_uid, batches_new, uid_to_block
         )
 
         # Compute softmaxed weights based on win rate.
@@ -707,7 +702,7 @@ class Validator:
         self.log_step(
             uids,
             uid_to_block,
-            pages_to_use,
+            pages,
             wins,
             win_rate,
             losses_per_uid,
@@ -818,10 +813,12 @@ class Validator:
         """Runs the validator loop, which continuously evaluates models and sets weights."""
         while True:
             try:
+                
                 while (
-                    self.metagraph.block.item() - self.last_epoch
-                    < self.config.blocks_per_epoch
+                        (self.metagraph.block.item() - self.last_epoch)
+                        < self.config.blocks_per_epoch
                 ):
+                    self.current_block = self.metagraph.block.item()                    
                     await self.try_run_step(ttl=60 * 20)
                     await self.try_sync_metagraph(ttl=60)
                     self.save_state()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bittensor
+bittensor==7.0.1
 huggingface_hub
 matplotlib
 pydantic==1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bittensor==7.0.1
+bittensor==6.9.3
 huggingface_hub
 matplotlib
 pydantic==1.10

--- a/tests/model/test_model_utils.py
+++ b/tests/model/test_model_utils.py
@@ -1,6 +1,6 @@
 import unittest
 from model.utils import get_model_criteria, get_hash_of_two_strings
-from constants import BLOCK_7B, BLOCK_FW_EDU_SCORE_2, ALLOWED_MODEL_TYPES_1, ALLOWED_MODEL_TYPES_2, DATASET_1, DATASET_2
+from constants import BLOCK_7B, ALLOWED_MODEL_TYPES_1, ALLOWED_MODEL_TYPES_2
 from model.data import ModelCriteria, TokenizerIdentifier
 
 
@@ -12,7 +12,6 @@ class TestModelUtils(unittest.TestCase):
         max_model_parameters=186_000_000,
         allowed_model_types=ALLOWED_MODEL_TYPES_1,
         tokenizer_identifier=TokenizerIdentifier.DISTILGPT_2,
-        evaluation_dataset=DATASET_1,
     )
     MODEL_CRITERIA_772M = ModelCriteria(
         sequence_length=1024,
@@ -21,7 +20,6 @@ class TestModelUtils(unittest.TestCase):
         max_model_parameters=772_000_000,
         allowed_model_types=ALLOWED_MODEL_TYPES_1,
         tokenizer_identifier=TokenizerIdentifier.DISTILGPT_2,
-        evaluation_dataset=DATASET_1,
     )
     MODEL_CRITERIA_7B = ModelCriteria(
         sequence_length=4096,
@@ -30,16 +28,6 @@ class TestModelUtils(unittest.TestCase):
         max_model_parameters=6_900_000_000,
         allowed_model_types=ALLOWED_MODEL_TYPES_2,
         tokenizer_identifier=TokenizerIdentifier.GPT_4_TIKTOKEN,
-        evaluation_dataset=DATASET_1,
-    )
-    MODEL_CRITERIA_FINEWEBEDU2 = ModelCriteria(
-        sequence_length=4096,
-        optimized=True,
-        max_model_bytes=15 * 1024 * 1024 * 1024,
-        max_model_parameters=6_900_000_000,
-        allowed_model_types=ALLOWED_MODEL_TYPES_2,
-        tokenizer_identifier=TokenizerIdentifier.GPT_4_TIKTOKEN,
-        evaluation_dataset=DATASET_2,
     )
     
     model_criteria_cases = [
@@ -50,9 +38,6 @@ class TestModelUtils(unittest.TestCase):
         (BLOCK_7B - 1, MODEL_CRITERIA_772M),
         (BLOCK_7B, MODEL_CRITERIA_7B),
         (BLOCK_7B + 1, MODEL_CRITERIA_7B),
-        (BLOCK_FW_EDU_SCORE_2 - 1, MODEL_CRITERIA_7B),
-        (BLOCK_FW_EDU_SCORE_2, MODEL_CRITERIA_FINEWEBEDU2),
-        (BLOCK_FW_EDU_SCORE_2 + 1, MODEL_CRITERIA_FINEWEBEDU2),
     ]
 
     def test_get_model_criteria(self):

--- a/tests/pretrain/test_dataset.py
+++ b/tests/pretrain/test_dataset.py
@@ -1,0 +1,47 @@
+import unittest
+
+import numpy as np
+
+import pretrain as pt
+from neurons import config
+
+# Get the config
+config = config.validator_config()
+
+def test_FineWeb_loader_page_copy():
+    """
+    Test that pages can be correctly copied from one FineWeb dataloader 
+    to another
+    """
+    # Some test params
+    NUM_PAGES = 20
+    
+    # Load a tokenizer
+    tokenizer = pt.model.get_tokenizer(cache_dir=config.model_dir)    
+
+    # First dataloader
+    dataloader_1 = pt.dataset.SubsetFineWebEdu2Loader(
+        batch_size=4,
+        sequence_length=4092,
+        num_pages=NUM_PAGES,
+        tokenizer=tokenizer)
+
+    # Assert that the number of pages loaded successfully are the one required
+    assert len(dataloader_1.pages) == NUM_PAGES
+
+
+    # Now create a second loader without automatic page loading
+    dataloader_2 = pt.dataset.SubsetFineWebEdu2Loader(
+        batch_size=4,
+        sequence_length=4092,
+        num_pages=None,
+        tokenizer=tokenizer)
+    
+    # Copy pages from the first dataloader
+    dataloader_2.fetch_data_for_pages(pages=dataloader_1.pages)
+
+    # Assert both dataloaders have the same pages
+    assert set(dataloader_1.pages) == set(dataloader_2.pages)
+
+    # Assert that both have the same buffers
+    assert np.array_equal(dataloader_1.buffer, dataloader_2.buffer)


### PR DESCRIPTION
**Context**

The current implementation of the dataset migration evaluates only models submitted after a specified block on the new dataset. This behavior does not align with our intended functionality.



**Goal**

The objective of this PR is to ensure that after the specified migration block, all models, regardless of their submission time, are evaluated on the new dataset. Additionally, once the migration block is reached, the code supporting the old dataset could be completely removed, streamlining the evaluation process.

