### PR TITLE
Hotfix: pushing migration block by 1 week

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -41,7 +41,7 @@ ROOT_DIR = Path(__file__).parent.parent
 BLOCK_7B = 2_786_061
 
 # Block at which FineWeb edu score 2 dataset is used for evaluation
-BLOCK_FW_EDU_SCORE_2 = 3_256_604
+BLOCK_FW_EDU_SCORE_2 = 3_307_004
 
 # FIXING MODEL CRITERIA
 


### PR DESCRIPTION
Migration block pushed to 3307004

This is a temporary fix to the current release to prevent migration to the new dataset today (25th or june 2024). A new patch should follow shortly to add some fixes to the migration logic