### PR TITLE
[WIP] Roel/remove sample packing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode/
 
 test-models/
+model-store/*
 
 # Exclude the Miner's directory for saving the models.
 local-models/

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -547,6 +547,8 @@ class Validator:
             tokenizer=tokenizer_old,
         )
 
+        batches_old = list(dataloader_old)
+
         # This is useful for logging to wandb
         pages = dataloader_old.get_page_names()
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -542,14 +542,9 @@ class Validator:
         ## First tokenizer (Prior to 7B models)
         tokenizer_old = pt.model.get_old_tokenizer(cache_dir=self.config.model_dir)
         dataloader_old = SubsetDataLoader(
-                batch_size=constants.batch_size,
-                sequence_length=constants.SEQUENCE_LENGTH_1,
-                num_pages=self.config.pages_per_eval, # The pages will be sampled inside the object
-                tokenizer=tokenizer_old,
-            )
-
-        batches_old = list(
-            dataloader_old
+            sequence_length=constants.SEQUENCE_LENGTH_1,
+            num_pages=self.config.pages_per_eval,  # The pages will be sampled inside the object
+            tokenizer=tokenizer_old,
         )
 
         # This is useful for logging to wandb
@@ -558,11 +553,10 @@ class Validator:
         ## Second tokenizer (For 7B models)
         tokenizer_new = pt.model.get_tokenizer(cache_dir=self.config.model_dir)
         dataloader_new = SubsetDataLoader(
-            batch_size=constants.batch_size,
             sequence_length=constants.SEQUENCE_LENGTH_2,
-            num_pages=None, # Do not automatically generate pages. They will be manually set.
+            num_pages=None,  # Do not automatically generate pages. They will be manually set.
             tokenizer=tokenizer_new,
-            )
+        )
 
         # Use the same pages as for models with old tokenizers
         dataloader_new.fetch_data_for_pages(pages=dataloader_old.pages)

--- a/pretrain/dataset.py
+++ b/pretrain/dataset.py
@@ -43,12 +43,20 @@ class SubsetFineWebEdu2Loader(IterableDataset):
         num_pages=None,
         tokenizer: AutoTokenizer=None,
     ):
-        self.batch_size = batch_size
         self.sequence_length = sequence_length
         self.num_pages = num_pages
         self.num_rows_per_page = 100
         self.tokenizer = tokenizer
 
+        # Use a default PAD token ID if the tokenizer does not provide one
+        # (e.g. GPT-2 does not have a padding token)
+        # If the tokenizer does not have a padding token, use the EOS token.
+
+        self.pad_token_id = (
+            self.tokenizer.pad_token_id
+            if self.tokenizer.pad_token_id is not None
+            else self.tokenizer.eos_token_id
+        )
         self.buffer = []
 
         # Get the dataset configs and their row sizes
@@ -91,11 +99,14 @@ class SubsetFineWebEdu2Loader(IterableDataset):
 
                 # Add the page since the request was successful
                 self.pages.append((config_name, page, split))
-                
+
+                page_buffer = []
                 for row in response.json()["rows"]:
                     content = row["row"]["text"]
-                    self.buffer += self.tokenizer(content, truncation=True)["input_ids"]
-                    self.buffer += [self.tokenizer.eos_token_id]
+                    page_buffer += self.tokenizer(content, truncation=True)["input_ids"]
+                    page_buffer += [self.tokenizer.eos_token_id]
+
+                self.buffer.append(page_buffer)
 
             except requests.exceptions.RequestException as e:
                 attempts += 1
@@ -147,13 +158,15 @@ class SubsetFineWebEdu2Loader(IterableDataset):
 
                 response.raise_for_status()  # This will raise an HTTPError if the HTTP request returned an unsuccessful status code
 
+                page_buffer = []
                 for row in response.json()["rows"]:
                     content = row["row"]["text"]
-                    self.buffer += self.tokenizer(content, truncation=True)["input_ids"]
-                    self.buffer += [self.tokenizer.eos_token_id]
-                    
+                    page_buffer += self.tokenizer(content, truncation=True)["input_ids"]
+                    page_buffer += [self.tokenizer.eos_token_id]
+
+                self.buffer.append(page_buffer)
                 break  # If the request was successful, break out of the retry loop
-            
+
             except requests.exceptions.RequestException as e:
                 attempt += 1
                 bt.logging.warning(
@@ -292,21 +305,25 @@ class SubsetFineWebEdu2Loader(IterableDataset):
                         "Maximum retry limit reached. Unable to fetch data."
                     )
                     raise
-                
+
     def __iter__(self):
-        while len(self.buffer) >= self.sequence_length * self.batch_size:
-            batch = []
-            for _ in range(self.batch_size):
-                batch.append(torch.tensor(self.buffer[: self.sequence_length]))
-                self.buffer = self.buffer[self.sequence_length :]
-            yield torch.stack(batch)
+        while self.buffer:
+            page_buffer = self.buffer.pop(0)
+            if len(page_buffer) < self.sequence_length:
+                page_buffer += [self.pad_token_id] * (
+                    self.sequence_length - len(page_buffer)
+                )
+            yield torch.tensor(page_buffer[: self.sequence_length]).unsqueeze(0)
 
     def __next__(self):
-        batch = []
-        for _ in range(self.batch_size):
-            batch.append(torch.tensor(self.buffer[: self.sequence_length]))
-            self.buffer = self.buffer[self.sequence_length :]
-        return torch.stack(batch)
+        if not self.buffer:
+            raise StopIteration
+        page_buffer = self.buffer.pop(0)
+        if len(page_buffer) < self.sequence_length:
+            page_buffer += [self.pad_token_id] * (
+                self.sequence_length - len(page_buffer)
+            )
+        return torch.tensor(page_buffer[: self.sequence_length]).unsqueeze(0)
 
 
 class SubsetFalconLoader(IterableDataset):

--- a/pretrain/dataset.py
+++ b/pretrain/dataset.py
@@ -438,8 +438,7 @@ class SubsetFalconLoader(IterableDataset):
 def main():
     tokenizer = AutoTokenizer.from_pretrained("gpt2")
     # Display the padding and EOS token IDs
-    # pad_token_id = tokenizer.eos_token_id  # GPT-2 does not have a padding token, use EOS token
-    pad_token_id = "163163163"
+    pad_token_id = tokenizer.eos_token_id  # GPT-2 does not have a padding token, use EOS token
     eos_token_id = tokenizer.eos_token_id
 
     print(f"PAD token ID: {pad_token_id}")

--- a/pretrain/dataset.py
+++ b/pretrain/dataset.py
@@ -435,3 +435,31 @@ class SubsetFalconLoader(IterableDataset):
             batch.append(torch.tensor(self.buffer[: self.sequence_length]))
             self.buffer = self.buffer[self.sequence_length :]
         return torch.stack(batch)
+def main():
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    # Display the padding and EOS token IDs
+    # pad_token_id = tokenizer.eos_token_id  # GPT-2 does not have a padding token, use EOS token
+    pad_token_id = "163163163"
+    eos_token_id = tokenizer.eos_token_id
+
+    print(f"PAD token ID: {pad_token_id}")
+    print(f"EOS token ID: {eos_token_id}")
+
+    sequence_length = 500000
+    num_pages = 2
+
+    # Print other parameters
+    print(f"Sequence length: {sequence_length}")
+    print(f"Number of pages: {num_pages}")
+
+    dataset_loader = SubsetFineWebEdu2Loader(
+        sequence_length=sequence_length, num_pages=num_pages, tokenizer=tokenizer
+    )
+
+    for i, batch in enumerate(dataset_loader):
+        print(f"Batch {i + 1}:")
+        print(batch)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Main Changes Made

1. **Buffer as List of Pages**:
    - The buffer is now a list where each element is a list of token IDs from a single page.

2. **Batch Size Always 1**:
    - The `__iter__` and `__next__` methods now yield one page at a time, wrapped in a tensor with an added dimension to simulate batch size 1.

3. **Padding**:
    - If a page doesn't have enough tokens to fill `sequence_length`, it is padded with the tokenizer's pad token.

## Detailed Explanation

1. **Initialization**: 
   - In the `__init__` method, the buffer is initialized as an empty list, and `_fetch_data_to_buffer` is called to pre-fetch data if `num_pages` is specified.

2. **Data Fetching Methods**:
   - `_fetch_data_to_buffer`, `fetch_data_for_pages`, and `_fetch_data_for_page` are modified to store tokenized data from each page as a separate list within the buffer.
   
3. **Iteration**:
   - The `__iter__` and `__next__` methods now yield a single page worth of data at a time, ensuring each page is padded to the required `sequence_length` if necessary.

### Usage Example



```python
tokenizer = AutoTokenizer.from_pretrained("gpt2")
# Display the padding and EOS token IDs
pad_token_id = tokenizer.eos_token_id  # GPT-2 does not have a padding token, use EOS token
eos_token_id = tokenizer.eos_token_id

print(f"PAD token ID: {pad_token_id}")
print(f"EOS token ID: {eos_token_id}")

sequence_length = 500000
num_pages = 2

# Print other parameters
print(f"Sequence length: {sequence_length}")
print(f"Number of pages: {num_pages}")

dataset_loader = SubsetFineWebEdu2Loader(
    sequence_length=sequence_length, num_pages=num_pages, tokenizer=tokenizer
)

for i, batch in enumerate(dataset_loader):
    print(f"Batch {i + 1}:")
    print(batch)