### PR TITLE
Removed sample packing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode/
 
 test-models/
+model-store/
 
 # Exclude the Miner's directory for saving the models.
 local-models/

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -778,6 +778,7 @@ class Validator:
                                 batches,
                                 self.config.device,
                                 tokenizer.eos_token_id,
+                                pad_token_id = dataloader.pad_token_id
                             ),
                             ttl=360,
                             mode="spawn",

--- a/pretrain/validation.py
+++ b/pretrain/validation.py
@@ -181,7 +181,7 @@ def compute_losses(
                 shift_logits = logits[..., :-1, :].contiguous()
                 shift_labels = inputs[..., 1:].contiguous()
                 # Flatten the tokens
-                loss_fct = torch.nn.CrossEntropyLoss()
+                loss_fct = torch.nn.CrossEntropyLoss(ignore_index=pad_token_id)
                 shift_logits = shift_logits.view(-1, model.config.vocab_size)
                 shift_labels = shift_labels.view(-1)
                 loss = loss_fct(shift_logits, shift_labels).item()


### PR DESCRIPTION
# Main Changes Made

1. **Buffer as List of Pages**:
    - The buffer is now a list where each element is a list of token IDs from a single page.

2. **Batch Size Always 1**:
    - The `__iter__` and `__next__` methods now yield one page at a time, wrapped in a tensor with an added dimension to simulate batch size 1.

3. **Padding**:
    - If a page doesn't have enough tokens to fill `sequence_length`, it is padded with the tokenizer's pad token.

## Detailed Explanation

1. **Initialization**: 
   - In the `__init__` method, the buffer is initialized as an empty list, and `_fetch_data_to_buffer` is called to pre-fetch data if `num_pages` is specified.

2. **Data Fetching Methods**:
   - `_fetch_data_to_buffer`, `fetch_data_for_pages`, and `_fetch_data_for_page` are modified to store tokenized data from each page as a separate list within the buffer.
   
3. **Iteration**:
   - The `__iter__` and `__next__` methods now yield a single page worth of data at a time, ensuring each page is padded to the required `sequence_length` if necessary.

### Usage Example


```python
tokenizer = AutoTokenizer.from_pretrained("gpt2")
# Display the padding and EOS token IDs
pad_token_id = tokenizer.eos_token_id  # GPT-2 does not have a padding token, use EOS token
eos_token_id = tokenizer.eos_token_id

print(f"PAD token ID: {pad_token_id}")
print(f"EOS token ID: {eos_token_id}")

sequence_length = 500000
num_pages = 2

# Print other parameters
print(f"Sequence length: {sequence_length}")
print(f"Number of pages: {num_pages}")

dataset_loader = SubsetFineWebEdu2Loader(
    sequence_length=sequence_length, num_pages=num_pages, tokenizer=tokenizer
)

for i, batch in enumerate(dataset_loader):
    print(f"Batch {i + 1}:")
    print(batch)