### PR TITLE
Log metadata in eval loop.

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -725,21 +725,25 @@ class Validator:
             pages_per_eval = constants.pages_per_eval_pack
 
         # If the option is set in the config, override
-        pages_per_eval = self.config.pages_per_eval if self.config.pages_per_eval is not None else pages_per_eval
+        pages_per_eval = (
+            self.config.pages_per_eval
+            if self.config.pages_per_eval is not None
+            else pages_per_eval
+        )
 
-        bt.logging.debug(f'Sample packing is set to: {pack_samples}.')
-        bt.logging.debug(f'Number of pages per evaluation step is: {pages_per_eval}')
+        bt.logging.debug(f"Sample packing is set to: {pack_samples}.")
+        bt.logging.debug(f"Number of pages per evaluation step is: {pages_per_eval}")
 
         dataloader = SubsetDataLoader(
             batch_size=constants.batch_size,
             sequence_length=competition.constraints.sequence_length,
-            num_pages= pages_per_eval,
+            num_pages=pages_per_eval,
             tokenizer=tokenizer,
-            pack_samples=pack_samples
-            )
+            pack_samples=pack_samples,
+        )
 
         batches = list(dataloader)
-        bt.logging.debug(f'Number of validation batches is {len(batches)}')
+        bt.logging.debug(f"Number of validation batches is {len(batches)}")
 
         # This is useful for logging to wandb
         pages = dataloader.get_page_names()
@@ -758,10 +762,10 @@ class Validator:
         compute_loss_perf = PerfMonitor("Eval: Compute loss")
 
         for uid_i in uids:
-            bt.logging.trace(f"Computing model losses for uid:{uid_i}.")
-
             # This variable should be overwritten below if the model has metadata.
             losses: typing.List[float] = [math.inf for _ in range(len(batches))]
+
+            bt.logging.trace(f"Getting metadata for uid: {uid_i}.")
 
             # Check that the model is in the tracker.
             with self.metagraph_lock:
@@ -776,6 +780,10 @@ class Validator:
                 and model_i_metadata.id.competition_id == competition.id
             ):
                 try:
+                    bt.logging.info(
+                        f"Evaluating uid: {uid_i} / hotkey: {hotkey} with metadata: {model_i_metadata}."
+                    )
+
                     # Update the block this uid last updated their model.
                     uid_to_block[uid_i] = model_i_metadata.block
 
@@ -795,7 +803,7 @@ class Validator:
                                 batches,
                                 self.config.device,
                                 tokenizer.eos_token_id,
-                                pack_samples
+                                pack_samples,
                             ),
                             ttl=400,
                             mode="spawn",
@@ -912,7 +920,9 @@ class Validator:
         # If the model has any significant weight, prioritize by weight with greater weights being kept first.
         # Then for the unweighted models, prioritize by win_rate.
         # Use the competition weights from the tracker which also handles moving averages.
-        tracker_competition_weights = self.competition_tracker.get_competition_weights(competition.id)
+        tracker_competition_weights = self.competition_tracker.get_competition_weights(
+            competition.id
+        )
         model_prioritization = {
             uid: (
                 # Add 1 to ensure it is always greater than a win rate.
@@ -952,7 +962,6 @@ class Validator:
             compute_loss_perf,
         )
 
-
         # Increment the number of completed run steps by 1
         self.run_step_count += 1
 
@@ -981,7 +990,9 @@ class Validator:
         }
 
         # The sub-competition weights
-        sub_competition_weights = torch.softmax(model_weights / constants.temperature, dim=0)
+        sub_competition_weights = torch.softmax(
+            model_weights / constants.temperature, dim=0
+        )
 
         for idx, uid in enumerate(uids):
             step_log["uid_data"][str(uid)] = {
@@ -1069,7 +1080,10 @@ class Validator:
                     str(uid): uid_data[str(uid)]["win_total"] for uid in uids
                 },
                 "weight_data": {str(uid): self.weights[uid].item() for uid in uids},
-                "norm_weight_data": {str(uid): sub_competition_weights[i].item() for i, uid in enumerate(uids)},
+                "norm_weight_data": {
+                    str(uid): sub_competition_weights[i].item()
+                    for i, uid in enumerate(uids)
+                },
                 "competition_id": {
                     str(uid): uid_to_competition_id[uid]
                     for uid in uids
@@ -1094,7 +1108,7 @@ class Validator:
                 step=self.last_wandb_step,
             )
 
-            self.last_wandb_step+=1
+            self.last_wandb_step += 1
 
     def _get_uids_to_competition_ids(
         self,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -33,6 +33,7 @@ import wandb
 import constants
 from taoverse.metagraph import utils as metagraph_utils
 from taoverse.metagraph.metagraph_syncer import MetagraphSyncer
+from taoverse.model import utils as model_utils
 from taoverse.model.competition import utils as competition_utils
 from taoverse.model.competition.competition_tracker import CompetitionTracker
 from taoverse.model.competition.data import Competition
@@ -781,7 +782,7 @@ class Validator:
             ):
                 try:
                     bt.logging.info(
-                        f"Evaluating uid: {uid_i} / hotkey: {hotkey} with metadata: {model_i_metadata}."
+                        f"Evaluating uid: {uid_i} / hotkey: {hotkey} with metadata: {model_i_metadata} and hf_url: {model_utils.get_hf_url(model_i_metadata)}."
                     )
 
                     # Update the block this uid last updated their model.


### PR DESCRIPTION
Logs look as follows:

Evaluation:
```
2024-08-18 22:30:35.716 |      DEBUG       | Competition 1 | Computing losses on [71, 140, 148, 154, 94]
2024-08-18 22:30:35.716 |      DEBUG       | Pages used are [821968790, 710143056, 150266581, 787989376, 769501251]
2024-08-18 22:30:35.716 |      TRACE       | Getting metadata for uid: 71.
2024-08-18 22:30:35.716 |       INFO       | Evaluating uid: 71 / hotkey: 5FbHSCqz2Be6zAxEqgEkKvLoJQcjZrqyt2HrTk2V62WnJWYH with metadata: ModelMetadata(id=ModelId(namespace='TdL', name='test_repo', competition_id=1, commit='618fd986e24698eaf1873d300bd35fe66faa7b72', hash=None, secure_hash='qYsS46HVGJ0GDsvF5QDH3zqJuvCUNFSs6BL7YNycF3c='), block=3601787) and hf_url: https://huggingface.co/TdL/test_repo/tree/618fd986e24698eaf1873d300bd35fe66faa7b72.
```

Step Log:
```
024-08-19 01:52:39.015 |      TRACE       | Computed model losses for uid:94 with average loss: 2.5007286902666093                                                          | 1.58G/4.97G [00:45<01:38, 34.5MB/s]
2024-08-19 01:52:39.039 |      TRACE       | Saving validator state.
2024-08-19 01:52:39.042 |      DEBUG       | Eval: Load model performance: N=5 | Min=1.08 s | Max=1.21 s | Median=1.11 s | P90=1.19 s
2024-08-19 01:52:39.043 |      DEBUG       | Eval: Compute loss performance: N=5 | Min=55.91 s | Max=57.64 s | Median=56.02 s | P90=57.12 s
                                                                                                  Step
┏━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ uid ┃ average_loss ┃ win_rate ┃ win_total ┃ weights ┃ competition_weights ┃ block   ┃ competition ┃ hugging_face_url                                                                                 ┃
┡━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│  71 │ 2.5007       │ 0.678    │ 1356      │ 0.0449  │ 0.1419              │ 3601787 │ 1           │ https://huggingface.co/TdL/test_repo/tree/618fd986e24698eaf1873d300bd35fe66faa7b72               │
│ 140 │ 2.5249       │ 0.446    │ 892       │ 0.0     │ 0.0                 │ 3580597 │ 1           │ https://huggingface.co/TdL/subnet9_best/tree/ccbbb71f05c4c76ceba6f136c8ca3a4ae25eb56c            │
│ 148 │ 2.5537       │ 0.252    │ 504       │ 0.0     │ 0.0                 │ 3565376 │ 1           │ https://huggingface.co/TdL/subnet9_best/tree/e317afa7f3c74fc8e261ad68835075dbc27d0e3b            │
│ 154 │ 2.5249       │ 0.696    │ 1392      │ 0.0951  │ 0.8581              │ 3580478 │ 1           │ https://huggingface.co/Deeptensorlab/subnet9_772_4/tree/518bbae46bb8a6d739b88c7befdbb69bee13acc2 │
│  94 │ 2.5007       │ 0.428    │ 856       │ 0.0     │ 0.0                 │ 3601791 │ 1           │ https://huggingface.co/TdL/test_repo/tree/618fd986e24698eaf1873d300bd35fe66faa7b72               │
└─────┴──────────────┴──────────┴───────────┴─────────┴─────────────────────┴─────────┴─────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────┘
```