### PR TITLE
Bump pretraining/taoverse versions and improve logging.

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -34,7 +34,7 @@ from typing import Dict, List, Tuple
 # ---------------------------------
 
 # Release
-__version__ = "4.1.1"
+__version__ = "4.1.2"
 
 # Validator schema version
 __validator_version__ = "3.0.0"

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -24,6 +24,7 @@ from taoverse.model.competition.data import (
     ModelConstraints,
     NormValidationConstraints,
 )
+from taoverse.model.competition.epsilon import FixedEpsilon
 from competitions.data import CompetitionId
 
 from typing import Dict, List, Tuple
@@ -103,6 +104,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
         allowed_architectures=ALLOWED_MODEL_TYPES_1,
         tokenizer="distilgpt2",
         eval_block_delay=0,
+        epsilon_func=FixedEpsilon(0.005),
     ),
     CompetitionId.B7_MODEL: ModelConstraints(
         max_model_parameter_size=6_900_000_000,
@@ -115,6 +117,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
             "attn_implementation": "flash_attention_2",
         },
         eval_block_delay=0,
+        epsilon_func=FixedEpsilon(0.005),
     ),
     CompetitionId.B3_MODEL: ModelConstraints(
         max_model_parameter_size=3_400_000_000,
@@ -127,6 +130,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
             "attn_implementation": "flash_attention_2",
         },
         eval_block_delay=0,
+        epsilon_func=FixedEpsilon(0.005),
     ),
 }
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1022,7 +1022,7 @@ class Validator:
         table.add_column("win_rate", style="magenta", overflow="fold")
         table.add_column("win_total", style="magenta", overflow="fold")
         table.add_column("total_weight", style="magenta", overflow="fold")
-        table.add_column("compe_weight", style="magenta", overflow="fold")
+        table.add_column("comp_weight", style="magenta", overflow="fold")
         table.add_column("block", style="magenta", overflow="fold")
         table.add_column("comp", style="magenta", overflow="fold")
         for idx, uid in enumerate(uids):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ transformers==4.44.1
 wandb
 datasets
 flash-attn
-taoverse==1.0.1
+taoverse==1.0.2


### PR DESCRIPTION
The step log table now correctly wraps rather than eliding text.

```
0|vali  | 2024-08-23 18:24:28.959 |      TRACE       | Computed model losses for uid:209 with average loss: 2.4440023282712158
0|vali  | 2024-08-23 18:24:28.967 |      TRACE       | Saving validator state.
0|vali  |                                       Step
0|vali  | ┏━━━━━┳━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┳━━━━━━┓
0|vali  | ┃     ┃        ┃ average ┃ win_ra ┃ win_tot ┃ total_ ┃ comp_w ┃        ┃      ┃
0|vali  | ┃ uid ┃ hf     ┃ _loss   ┃ te     ┃ al      ┃ weight ┃ eight   ┃ block  ┃ comp ┃
0|vali  | ┡━━━━━╇━━━━━━━━╇━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━╇━━━━━━━━╇━━━━━━┩
0|vali  | │ 209 │ rwh/me │ 2.444   │ 0      │ 0       │ 1.0    │ 1.0     │ 364637 │ 2    │
0|vali  | │     │ diumA  │         │        │         │        │         │ 7      │      │
0|vali  | └─────┴────────┴─────────┴────────┴─────────┴────────┴─────────┴────────┴──────┘
0|vali  | Weights > 0.001
0|vali  | ┏━━━━━┳━━━━━━━━┓
0|vali  | ┃ uid ┃ weight ┃
0|vali  | ┡━━━━━╇━━━━━━━━┩
0|vali  | │ 209 │ 1.0    │
0|vali  | └─────┴────────┘
```