### PR TITLE
Define per-competition maximum model size (in bytes)

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -105,6 +105,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
         tokenizer="distilgpt2",
         eval_block_delay=0,
         epsilon_func=FixedEpsilon(0.005),
+        max_bytes=5 * 1024 * 1024 * 1024,
     ),
     CompetitionId.B7_MODEL: ModelConstraints(
         max_model_parameter_size=6_900_000_000,
@@ -118,6 +119,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
         },
         eval_block_delay=0,
         epsilon_func=FixedEpsilon(0.005),
+        max_bytes=15 * 1024 * 1024 * 1024,
     ),
     CompetitionId.B3_MODEL: ModelConstraints(
         max_model_parameter_size=3_400_000_000,
@@ -131,6 +133,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
         },
         eval_block_delay=0,
         epsilon_func=FixedEpsilon(0.005),
+        max_bytes=15 * 1024 * 1024 * 1024,
     ),
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ transformers==4.44.1
 wandb
 datasets
 flash-attn
-taoverse==1.0.2
+taoverse==1.0.4


### PR DESCRIPTION
This is a necessary precursor to releasing the 14b competition.

NOTE: Not yet fully tested. Waiting for taoverse package update