### PR TITLE
Use per competition epsilon func.

### DIFF
--- a/docs/validator.md
+++ b/docs/validator.md
@@ -38,12 +38,12 @@ You can view the entire validation system by reading the code in `neurons/valida
         set_weights( weight )
 ```
 
-The behaviour of `iswin( loss_a, loss_b, block_a, block_b, epsilon)` function intentionally skews the win function to reward models which have been hosted earlier such that newer models are only better than others iff their loss is `epsilon` percent lower accoring to the following function. Currently `epsilon` is set to 1% and is a hyper parameter of the mechanism
+The behaviour of `iswin( loss_a, loss_b, block_a, block_b, epsilon_func, curr_block)` function intentionally skews the win function to reward models which have been hosted earlier such that newer models are only better than others iff their loss is `epsilon` percent lower accoring to the following function. `epsilon` is calculated based on a per-competition specified function based on the distance from the earlier model block to the current block.
 
 ```python
-def iswin( loss_a, loss_b, block_a, block_b, epsilon):
-    loss_a = (1 - epsilon) * loss_a if block_a < block_b else loss_a
-    loss_b = (1 - epsilon) * loss_b if block_b < block_a else loss_b
+def iswin(loss_a, loss_b, block_a, block_b, epsilon_func, curr_block):
+    loss_a = (1 - epsilon_func(curr_block, block_a)) * loss_a if block_a < block_b else loss_a
+    loss_b = (1 - epsilon_func(curr_block, block_b)) * loss_b if block_b < block_a else loss_b
     return loss_a < loss_b
 ```
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -46,6 +46,7 @@ from taoverse.model.competition.competition_tracker import CompetitionTracker
 from taoverse.model.competition.data import Competition
 from taoverse.model.model_tracker import ModelTracker
 from taoverse.model.model_updater import MinerMisconfiguredError, ModelUpdater
+from taoverse.model.competition.epsilon import FixedEpsilon
 from taoverse.model.storage.chain.chain_model_metadata_store import (
     ChainModelMetadataStore,
 )
@@ -826,7 +827,12 @@ class Validator:
 
         # Compute wins and win rates per uid.
         wins, win_rate = pt.validation.compute_wins(
-            uids, losses_per_uid, batches, uid_to_block, constants.timestamp_epsilon
+            uids,
+            losses_per_uid,
+            batches,
+            uid_to_block,
+            competition.constraints.epsilon_func,
+            cur_block,
         )
 
         # Compute softmaxed weights based on win rate.
@@ -846,7 +852,8 @@ class Validator:
                     losses_per_uid,
                     batches,
                     uid_to_block,
-                    constants.timestamp_epsilon_experiment,
+                    FixedEpsilon(0.001),
+                    cur_block,
                 )
             )
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1017,9 +1017,11 @@ class Validator:
                 "uid": uid,
                 "block": uid_to_block[uid],
                 "hf": uid_to_hf[uid],
-                "competition_id": competition_id,
+                "competition_id": int(competition_id),
                 "average_loss": sum(losses_per_uid[uid]) / len(losses_per_uid[uid]),
-                "epsilon": competition_epsilon_func.compute_epsilon(current_block, uid_to_block[uid]),
+                "epsilon": competition_epsilon_func.compute_epsilon(
+                    current_block, uid_to_block[uid]
+                ),
                 "win_rate": win_rate[uid],
                 "win_total": wins[uid],
                 "weight": self.weights[uid].item(),
@@ -1111,7 +1113,7 @@ class Validator:
                     str(uid): sub_competition_weights[i].item()
                     for i, uid in enumerate(uids)
                 },
-                "competition_id": {str(uid): competition_id},
+                "competition_id": {str(uid): int(competition_id)},
                 "load_model_perf": {
                     "min": load_model_perf.min(),
                     "median": load_model_perf.median(),

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1019,7 +1019,7 @@ class Validator:
                 "hf": uid_to_hf[uid],
                 "competition_id": int(competition_id),
                 "average_loss": sum(losses_per_uid[uid]) / len(losses_per_uid[uid]),
-                "epsilon": competition_epsilon_func.compute_epsilon(
+                "epsilon_adv": competition_epsilon_func.compute_epsilon(
                     current_block, uid_to_block[uid]
                 ),
                 "win_rate": win_rate[uid],
@@ -1030,8 +1030,8 @@ class Validator:
         table = Table(title="Step", expand=True)
         table.add_column("uid", justify="right", style="cyan", no_wrap=True)
         table.add_column("hf", style="magenta", overflow="fold")
-        table.add_column("average_loss", style="magenta", overflow="fold")
-        table.add_column("epsilon", style="magenta", overflow="fold")
+        table.add_column("avg_loss", style="magenta", overflow="fold")
+        table.add_column("epsilon_adv", style="magenta", overflow="fold")
         table.add_column("win_rate", style="magenta", overflow="fold")
         table.add_column("win_total", style="magenta", overflow="fold")
         table.add_column("total_weight", style="magenta", overflow="fold")
@@ -1044,7 +1044,7 @@ class Validator:
                     str(uid),
                     str(step_log["uid_data"][str(uid)]["hf"]),
                     str(round(step_log["uid_data"][str(uid)]["average_loss"], 4)),
-                    str(round(step_log["uid_data"][str(uid)]["epsilon"], 4)),
+                    str(round(step_log["uid_data"][str(uid)]["epsilon_adv"], 4)),
                     str(round(step_log["uid_data"][str(uid)]["win_rate"], 4)),
                     str(step_log["uid_data"][str(uid)]["win_total"]),
                     str(round(self.weights[uid].item(), 4)),
@@ -1099,8 +1099,8 @@ class Validator:
                 "uid_data": {
                     str(uid): uid_data[str(uid)]["average_loss"] for uid in uids
                 },
-                "uid_epsilon": {
-                    str(uid): uid_data[str(uid)]["epsilon"] for uid in uids
+                "uid_epsilon_adv": {
+                    str(uid): uid_data[str(uid)]["epsilon_adv"] for uid in uids
                 },
                 "win_rate_data": {
                     str(uid): uid_data[str(uid)]["win_rate"] for uid in uids

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1090,12 +1090,10 @@ class Validator:
             uid_data = step_log["uid_data"]
 
             # Create a new dictionary with the required format
-            with self.metagraph_lock:
-                block = self.metagraph.block.item()
             graphed_data = {
                 "time": time.time(),
                 "step_competition_id": competition_id,
-                "block": block,
+                "block": current_block,
                 "uid_data": {
                     str(uid): uid_data[str(uid)]["average_loss"] for uid in uids
                 },

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1019,7 +1019,7 @@ class Validator:
                 "hf": uid_to_hf[uid],
                 "competition_id": competition_id,
                 "average_loss": sum(losses_per_uid[uid]) / len(losses_per_uid[uid]),
-                "epsilon": competition_epsilon_func(current_block, uid_to_block[uid]),
+                "epsilon": competition_epsilon_func.compute_epsilon(current_block, uid_to_block[uid]),
                 "win_rate": win_rate[uid],
                 "win_total": wins[uid],
                 "weight": self.weights[uid].item(),

--- a/pretrain/validation.py
+++ b/pretrain/validation.py
@@ -25,9 +25,17 @@ import constants
 import traceback
 import numpy as np
 import bittensor as bt
+from taoverse.model.competition.epsilon import EpsilonFunc
 
 
-def iswin(loss_i, loss_j, block_i, block_j, epsilon) -> bool:
+def iswin(
+    loss_i: float,
+    loss_j: float,
+    block_i: int,
+    block_j: int,
+    epsilon_func: EpsilonFunc,
+    current_block: int,
+) -> bool:
     """
     Determines the winner between two models based on the epsilon adjusted loss.
 
@@ -36,14 +44,23 @@ def iswin(loss_i, loss_j, block_i, block_j, epsilon) -> bool:
         loss_j (float): Loss of uid j on batch.
         block_i (int): Block of uid i.
         block_j (int): Block of uid j.
-        epsilon (float): How much advantage to give to the earlier block.
+        epsilon_func (EpsilonFunc): Function that determines how much advantage to give to the earlier block.
+        current_block: The current block.
 
     Returns:
         bool: True if loss i is better, False otherwise.
     """
-    # Adjust loss based on timestamp and pretrain epsilon
-    loss_i = (1 - epsilon) * loss_i if block_i < block_j else loss_i
-    loss_j = (1 - epsilon) * loss_j if block_j < block_i else loss_j
+    # Adjust loss based on timestamp and epsilon.
+    loss_i = (
+        (1 - epsilon_func.compute_epsilon(current_block, block_i)) * loss_i
+        if block_i < block_j
+        else loss_i
+    )
+    loss_j = (
+        (1 - epsilon_func.compute_epsilon(current_block, block_j)) * loss_j
+        if block_j < block_i
+        else loss_j
+    )
     return loss_i < loss_j
 
 
@@ -52,7 +69,8 @@ def compute_wins(
     losses_per_uid: typing.Dict[int, typing.List[float]],
     batches: typing.List[torch.FloatTensor],
     uid_to_block: typing.Dict[int, int],
-    epsilon: float
+    epsilon_func: EpsilonFunc,
+    current_block: int,
 ) -> typing.Tuple[typing.Dict[int, int], typing.Dict[int, float]]:
     """
     Computes the wins and win rate for each model based on loss comparison.
@@ -62,7 +80,8 @@ def compute_wins(
         losses_per_uid (dict): A dictionary of losses for each uid by batch.
         batches (List): A list of data batches.
         uid_to_block (dict): A dictionary of blocks for each uid.
-        epsilon (float): How much advantage to give to the earlier block.
+        epsilon_func (EpsilonFunc): Function that determines how much advantage to give to the earlier block.
+        current_block: The current block.
 
     Returns:
         tuple: A tuple containing two dictionaries, one for wins and one for win rates.
@@ -79,7 +98,13 @@ def compute_wins(
             for batch_idx, _ in enumerate(batches):
                 loss_i = losses_per_uid[uid_i][batch_idx]
                 loss_j = losses_per_uid[uid_j][batch_idx]
-                wins[uid_i] += 1 if iswin(loss_i, loss_j, block_i, block_j, epsilon) else 0
+                wins[uid_i] += (
+                    1
+                    if iswin(
+                        loss_i, loss_j, block_i, block_j, epsilon_func, current_block
+                    )
+                    else 0
+                )
                 total_matches += 1
         # Calculate win rate for uid i
         win_rate[uid_i] = wins[uid_i] / total_matches if total_matches > 0 else 0
@@ -145,11 +170,11 @@ def check_for_reasonable_output(
 
 
 def compute_losses(
-        model,
-        batches: typing.List[np.ndarray],
-        device: str,
-        pad_token_id: int,
-        sample_packing_used: bool,
+    model,
+    batches: typing.List[np.ndarray],
+    device: str,
+    pad_token_id: int,
+    sample_packing_used: bool,
 ) -> typing.List[float]:
     """
     Computes the losses for a given model on provided batches.
@@ -198,8 +223,8 @@ def compute_losses(
                     # For this reason, we want to ignore all but the
                     # first EOS token (the real one)
                     pad_mask = shift_labels == pad_token_id
-                    zeros = torch.zeros_like(shift_labels[...,:1])
-                    pad_mask = torch.cat((zeros, pad_mask[...,:-1]), dim=-1).bool()
+                    zeros = torch.zeros_like(shift_labels[..., :1])
+                    pad_mask = torch.cat((zeros, pad_mask[..., :-1]), dim=-1).bool()
                     # Set all the padded labels to -100, since the
                     # CrossEntropyLoss ignores -100 labels by default.
                     shift_labels[pad_mask] = -100


### PR DESCRIPTION
Example logs:

```
0|vali  | 2024-08-28 03:58:39.866 |      DEBUG       | Eval: Load model performance: N=2 | Min=1.28 s | Max=7.70 s | Median=4.49 s | P90=7.06 s
0|vali  | 2024-08-28 03:58:39.866 |      DEBUG       | Eval: Compute loss performance: N=2 | Min=1.74 min | Max=1.92 min | Median=1.83 min | P90=1.90 min
0|vali  |                                       Step
0|vali  | ┏━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┓
0|vali  | ┃     ┃       ┃ avera ┃       ┃       ┃       ┃ total ┃ comp_ ┃       ┃        ┃
0|vali  | ┃     ┃       ┃ ge_lo ┃ epsil ┃ win_r ┃ win_t ┃ _weig ┃ weigh ┃       ┃        ┃
0|vali  | ┃ uid ┃ hf    ┃ ss    ┃ on    ┃ ate   ┃ otal  ┃ ht    ┃ t     ┃ block ┃ comp   ┃
0|vali  | ┡━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━┩
0|vali  | │ 190 │ rwh/t │ 2.453 │ 0.005 │ 0.358 │ 179   │ 0.0   │ 0.0   │ 36740 │ Compet │
0|vali  | │     │ iny8  │ 7     │       │       │       │       │       │ 44    │ itionI │
0|vali  | │     │       │       │       │       │       │       │       │       │ d.M772 │
0|vali  | │     │       │       │       │       │       │       │       │       │ _MODEL │
0|vali  | │ 199 │ rwh/t │ 2.476 │ 0.005 │ 0.642 │ 321   │ 0.325 │ 1.0   │ 35954 │ Compet │
0|vali  | │     │ inyto │ 1     │       │       │       │ 6     │       │ 46    │ itionI │
0|vali  | │     │ o     │       │       │       │       │       │       │       │ d.M772 │
0|vali  | │     │       │       │       │       │       │       │       │       │ _MODEL │
0|vali  | └─────┴───────┴───────┴───────┴───────┴───────┴───────┴───────┴───────┴────────┘
0|vali  |     Weights > 0.001
0|vali  | ┏━━━━━┳━━━━━━━━┳━━━━━━┓
0|vali  | ┃ uid ┃ weight ┃ comp ┃
0|vali  | ┡━━━━━╇━━━━━━━━╇━━━━━━┩
0|vali  | │ 241 │ 0.6744 │ 2    │
0|vali  | │ 199 │ 0.3256 │ 1    │
0|vali  | └─────┴────────┴──────┘
```