### PR TITLE
Updated validator systerm requirements

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -40,7 +40,7 @@ from typing import Dict, List, Tuple
 __version__ = "4.3.0"
 
 # Validator schema version
-__validator_version__ = "3.2.0"
+__validator_version__ = "3.1.0"
 version_split = __validator_version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -53,7 +53,7 @@ It is important to note that this affects the game theoretics of the incentive l
 
 Validators will need enough disk space to store the models of miners being evaluated. Each model has a max size by block defined in [constants/__init__.py](https://github.com/macrocosm-os/pretraining/blob/main/constants/__init__.py#L57) and the validator has cleanup logic to remove old models. It is recommended to have at least 2 TB of disk space and 80GB of system memory.
 
-Validators will need enough processing power to evaluate their model. As of Apr 1st, 2024 it is required to have a GPU that supports [flash attention 2](https://github.com/Dao-AILab/flash-attention) with atleast 48 GB of VRAM and at least 38 TFLOPs for half precision (bfloat 16) operations.
+Validators will need enough processing power to evaluate their model. As of Sept 2nd, 2024, an upgrade to the Nvidia A100 GPU with 80GB of VRAM is required. This GPU's high throughput and FLOPs enable the running of 14B models without impacting the speed of the validation cycle. Although only 40GB of VRAM is necessary, we have observed that A100 GPUs with 80GB are more readily available and are offered at a comparable price to the 40GB variants. The additional VRAM provided by this GPU will allows more flexibility for optimization in future releases, enabling larger validation batch sizes to enhance the stability of the validation process by reducing scoring variance.
 
 # Getting Started
 


### PR DESCRIPTION
- Reverted validator schema version to 3.1.0 since it was unnecessarily bumped in a previous PR
- Updated validator system requirements to require use of A100 with 80GB.