### PR TITLE
Release 4.4.0

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -37,7 +37,7 @@ from typing import Dict, List, Tuple
 # ---------------------------------
 
 # Release
-__version__ = "4.3.0"
+__version__ = "4.4.0"
 
 # Validator schema version
 __validator_version__ = "3.1.0"
@@ -284,6 +284,27 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
             ),
         ],
     ),
+    (
+        3_849_722,
+        [
+            Competition(
+                CompetitionId.M772_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY[CompetitionId.M772_MODEL],
+                0.14,
+            ),
+            Competition(
+                CompetitionId.B3_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY[CompetitionId.B3_MODEL],
+                0.29,
+            ),
+            Competition(
+                CompetitionId.B14_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY[CompetitionId.B14_MODEL],
+                0.57,
+            ),
+        ],
+    ),
+
 ]
 
 for block_and_competitions in COMPETITION_SCHEDULE_BY_BLOCK:
@@ -308,17 +329,9 @@ alpha = 0.5
 # 0.01 gives ~96% to best model with only ~3 receiving any weights.
 temperature = 0.01
 
-# block to activate sample unpacking
-sample_unpack_block = BLOCK_3B_7BSTAR_UNPACK
-
 # validators number of pages to eval over miners on each step.
 pages_per_eval_unpack = 5  # With sample unpacking
 pages_per_eval_pack = 18
-
-timestamp_epsilon_experiment_start_block = BLOCK_3B_7BSTAR_UNPACK
-timestamp_epsilon_experiment_end_block = 3_750_683
-timestamp_epsilon_experiment = 0.001
-timestamp_epsilon_experiment_weight_percent = 0.123
 
 # validator eval batch size.
 batch_size = 1

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -40,7 +40,7 @@ from typing import Dict, List, Tuple
 __version__ = "4.3.0"
 
 # Validator schema version
-__validator_version__ = "3.2.0"
+__validator_version__ = "3.1.0"
 version_split = __validator_version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -53,7 +53,7 @@ It is important to note that this affects the game theoretics of the incentive l
 
 Validators will need enough disk space to store the models of miners being evaluated. Each model has a max size by block defined in [constants/__init__.py](https://github.com/macrocosm-os/pretraining/blob/main/constants/__init__.py#L57) and the validator has cleanup logic to remove old models. It is recommended to have at least 2 TB of disk space and 80GB of system memory.
 
-Validators will need enough processing power to evaluate their model. As of Apr 1st, 2024 it is required to have a GPU that supports [flash attention 2](https://github.com/Dao-AILab/flash-attention) with atleast 48 GB of VRAM and at least 38 TFLOPs for half precision (bfloat 16) operations.
+Validators will need enough processing power to evaluate their model. As of Sept 2nd, 2024, an upgrade to the Nvidia A100 GPU with 80GB of VRAM is required. This GPU's high throughput and FLOPs enable the running of 14B models without impacting the speed of the validation cycle. Although only 40GB of VRAM is necessary, we have observed that A100 GPUs with 80GB are more readily available and are offered at a comparable price to the 40GB variants. The additional VRAM provided by this GPU will allows more flexibility for optimization in future releases, enabling larger validation batch sizes to enhance the stability of the validation process by reducing scoring variance.
 
 # Getting Started
 


### PR DESCRIPTION
## Changes 

- Includes deactivation block for sunsetting 7B competition (competition ID 0). Block `3849722`.
- The 0.15 reward previously attributed to 7B competition will be added to the 14B competition whose reward will total `0.57`.
- No action to be taken by the validators other than `pip install -e .` of the new release package.