### PR TITLE
Increased ttl for loss computation

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -252,7 +252,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY_2: Dict[
             "attn_implementation": "flash_attention_2",
         },
         eval_block_delay=0,
-        epsilon_func=LinearDecay(0.005, 0.0001, 100800),
+        epsilon_func=LinearDecay(0.005, 0.0001, 50400),
         max_bytes=29 * 1024 * 1024 * 1024,
     ),
 }
@@ -419,7 +419,7 @@ sample_pack_block = BLOCK_SAMPLE_PACK
 
 # validators number of pages to eval over miners on each step.
 pages_per_eval_unpack = 5  # With sample unpacking
-pages_per_eval_pack = 18
+pages_per_eval_pack = 11
 
 # validator eval batch size.
 batch_size = 1

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -891,11 +891,12 @@ class Validator:
                                 tokenizer.eos_token_id,
                                 pack_samples,
                             ),
-                            ttl=400,
+                            ttl=430,
                             mode="spawn",
                         )
 
                     del model_i
+                    
                 except Exception as e:
                     bt.logging.error(
                         f"Error in eval loop: {e}. Setting losses for uid: {uid_i} to infinity."


### PR DESCRIPTION
- Reducing to 11 validation pages instead of 18.
- increasing TTL to 430s instead of 400 (Although all 14B models complete validation under 400s seconds).
- Also reducing decay period to 1 week instead of two for 14B. Two weeks seems to be too long for these small loss changes