### PR TITLE
Release 4.5.2

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -252,7 +252,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY_2: Dict[
             "attn_implementation": "flash_attention_2",
         },
         eval_block_delay=0,
-        epsilon_func=LinearDecay(0.005, 0.0001, 100800),
+        epsilon_func=LinearDecay(0.005, 0.0001, 50400),
         max_bytes=29 * 1024 * 1024 * 1024,
     ),
 }
@@ -419,7 +419,7 @@ sample_pack_block = BLOCK_SAMPLE_PACK
 
 # validators number of pages to eval over miners on each step.
 pages_per_eval_unpack = 5  # With sample unpacking
-pages_per_eval_pack = 18
+pages_per_eval_pack = 11
 
 # validator eval batch size.
 batch_size = 1

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -34,10 +34,10 @@ from typing import Dict, List, Tuple
 # ---------------------------------
 
 # Release
-__version__ = "4.5.1"
+__version__ = "4.5.2"
 
 # Validator schema version
-__validator_version__ = "3.2.0"
+__validator_version__ = "3.3.0"
 version_split = __validator_version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))
@@ -252,7 +252,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY_2: Dict[
             "attn_implementation": "flash_attention_2",
         },
         eval_block_delay=0,
-        epsilon_func=LinearDecay(0.005, 0.0001, 50400),
+        epsilon_func=LinearDecay(0.005, 0.0001, 72000),
         max_bytes=29 * 1024 * 1024 * 1024,
     ),
 }

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -891,11 +891,12 @@ class Validator:
                                 tokenizer.eos_token_id,
                                 pack_samples,
                             ),
-                            ttl=400,
+                            ttl=430,
                             mode="spawn",
                         )
 
                     del model_i
+                    
                 except Exception as e:
                     bt.logging.error(
                         f"Error in eval loop: {e}. Setting losses for uid: {uid_i} to infinity."


### PR DESCRIPTION
## Changes

- Bumped validator version to force all validators to reevaluate models that have been excluded with 'inf' loss due to the low compute loss TTL in 4.5.0.
- Decay period for 14B has been temporarily extended from 7 to 10 days, so models that had been excluded get a second chance to get a fair ranking.