### PR TITLE
Release 4.5.3

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -252,7 +252,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY_2: Dict[
             "attn_implementation": "flash_attention_2",
         },
         eval_block_delay=0,
-        epsilon_func=LinearDecay(0.005, 0.0001, 100800),
+        epsilon_func=LinearDecay(0.005, 0.0001, 50400),
         max_bytes=29 * 1024 * 1024 * 1024,
     ),
 }
@@ -419,7 +419,7 @@ sample_pack_block = BLOCK_SAMPLE_PACK
 
 # validators number of pages to eval over miners on each step.
 pages_per_eval_unpack = 5  # With sample unpacking
-pages_per_eval_pack = 18
+pages_per_eval_pack = 11
 
 # validator eval batch size.
 batch_size = 1

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -34,10 +34,10 @@ from typing import Dict, List, Tuple
 # ---------------------------------
 
 # Release
-__version__ = "4.5.1"
+__version__ = "4.5.2"
 
 # Validator schema version
-__validator_version__ = "3.2.0"
+__validator_version__ = "3.3.0"
 version_split = __validator_version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))
@@ -252,7 +252,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY_2: Dict[
             "attn_implementation": "flash_attention_2",
         },
         eval_block_delay=0,
-        epsilon_func=LinearDecay(0.005, 0.0001, 50400),
+        epsilon_func=LinearDecay(0.005, 0.0001, 72000),
         max_bytes=29 * 1024 * 1024 * 1024,
     ),
 }

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -34,10 +34,10 @@ from typing import Dict, List, Tuple
 # ---------------------------------
 
 # Release
-__version__ = "4.5.2"
+__version__ = "4.5.3"
 
 # Validator schema version
-__validator_version__ = "3.3.0"
+__validator_version__ = "3.4.0"
 version_split = __validator_version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -891,11 +891,12 @@ class Validator:
                                 tokenizer.eos_token_id,
                                 pack_samples,
                             ),
-                            ttl=400,
+                            ttl=430,
                             mode="spawn",
                         )
 
                     del model_i
+                    
                 except Exception as e:
                     bt.logging.error(
                         f"Error in eval loop: {e}. Setting losses for uid: {uid_i} to infinity."

--- a/tests/pretrain/test_validation.py
+++ b/tests/pretrain/test_validation.py
@@ -1,0 +1,167 @@
+import unittest
+import pretrain as pt
+from taoverse.model.competition.epsilon import LinearDecay
+
+
+class TestValidation(unittest.TestCase):
+    def test_compute_competitive_uids_filters_clones(self):
+        # Check that if the current top model submits a few clones, they are filtered out.
+        uid_to_average_loss = {100: 0.5, 50: 0.5, 75: 0.499}
+        uid_to_block = {100: 1000, 50: 2000, 75: 2001}
+        epsilon_func = LinearDecay(0.005, 0.0001, 1000)
+        self.assertEqual(
+            sorted(
+                pt.validation.compute_competitive_uids(
+                    uid_to_average_loss, uid_to_block, epsilon_func
+                )
+            ),
+            [75, 100],
+        )
+
+        # Check that if a new top model submits clones, they are filtered out.
+        uid_to_average_loss = {100: 0.5, 50: 0.499, 75: 0.499}
+        uid_to_block = {100: 1000, 50: 2000, 75: 2001}
+        epsilon_func = LinearDecay(0.005, 0.0001, 1000)
+        self.assertEqual(
+            sorted(
+                pt.validation.compute_competitive_uids(
+                    uid_to_average_loss, uid_to_block, epsilon_func
+                )
+            ),
+            [50, 100],
+        )
+
+    def test_compute_competitive_uids_better_models_sequentially_better(self):
+        # Each uploaded model is better than the previous. Expect to keep all of them.
+        uid_to_average_loss = {100: 0.5, 50: 0.499, 75: 0.498}
+        uid_to_block = {100: 1000, 50: 2000, 75: 2500}
+        epsilon_func = LinearDecay(0.005, 0.0001, 1000)
+        self.assertEqual(
+            sorted(
+                pt.validation.compute_competitive_uids(
+                    uid_to_average_loss, uid_to_block, epsilon_func
+                )
+            ),
+            [50, 75, 100],
+        )
+
+    def test_compute_competitive_uids_less_than_epsilon_better(self):
+        # Models are sequentially better, but less than epislon at full decay. Expect to only keep the first.
+        uid_to_average_loss = {100: 0.5, 50: 0.4999, 75: 0.499}
+        uid_to_block = {100: 1000, 50: 2000, 75: 2500}
+        epsilon_func = LinearDecay(0.005, 0.01, 1000)
+        self.assertEqual(
+            sorted(
+                pt.validation.compute_competitive_uids(
+                    uid_to_average_loss, uid_to_block, epsilon_func
+                )
+            ),
+            [100],
+        )
+
+    def test_compute_competitive_uids_later_worse_model_filtered(self):
+        # Models are sequentially better, but the last one is worse than a previous model.
+        uid_to_average_loss = {100: 0.5, 50: 0.498, 75: 0.499}
+        uid_to_block = {100: 1000, 50: 2000, 75: 2500}
+        epsilon_func = LinearDecay(0.005, 0.0001, 1000)
+        self.assertEqual(
+            sorted(
+                pt.validation.compute_competitive_uids(
+                    uid_to_average_loss, uid_to_block, epsilon_func
+                )
+            ),
+            [50, 100],
+        )
+
+    def test_compute_competitive_uids_few_models(self):
+        # Make sure the function works with none or only a few models.
+        epsilon_func = LinearDecay(0.005, 0.0001, 1000)
+        self.assertEqual(
+            pt.validation.compute_competitive_uids({}, {}, epsilon_func), []
+        )
+        self.assertEqual(
+            pt.validation.compute_competitive_uids(
+                {100: 0.5}, {100: 1000}, epsilon_func
+            ),
+            [100],
+        )
+        self.assertEqual(
+            pt.validation.compute_competitive_uids(
+                {100: 0.5, 50: 0.7}, {100: 1000, 50: 2000}, epsilon_func
+            ),
+            [100],
+        )
+
+    def test_compute_competitive_uids_same_block(self):
+        # Make sure that if two models are uploaded at the same block, the one with the lower average loss is kept.
+        uid_to_average_loss = {100: 0.5, 50: 0.4}
+        uid_to_block = {100: 1000, 50: 1000}
+        epsilon_func = LinearDecay(0.005, 0.0001, 1000)
+        self.assertEqual(
+            sorted(
+                pt.validation.compute_competitive_uids(
+                    uid_to_average_loss, uid_to_block, epsilon_func
+                )
+            ),
+            [50],
+        )
+
+        # Check that if a new top model submits clones, they are filtered out.
+        uid_to_average_loss = {100: 0.5, 50: 0.499, 75: 0.499}
+        uid_to_block = {100: 1000, 50: 2000, 75: 2001}
+        epsilon_func = LinearDecay(0.005, 0.0001, 1000)
+        self.assertEqual(
+            sorted(
+                pt.validation.compute_competitive_uids(
+                    uid_to_average_loss, uid_to_block, epsilon_func
+                )
+            ),
+            [50, 100],
+        )
+
+    def test_compute_wins_one_uid(self):
+        # Verifies compute_wins works with a single uid.
+        wins, win_rates = pt.validation.compute_wins(
+            [100], {100: 0.5}, {100: 1000}, LinearDecay(0.005, 0.0001, 1000), 1000
+        )
+        self.assertEqual(wins, {100: 0})
+        self.assertEqual(win_rates, {100: 1.0})
+
+    def test_compute_filtered_win_rates(self):
+        # Mimic what the validator does by first filtering the models and then computing win rates.
+
+        # The current top model with submitted clones.
+        uid_to_average_loss = {100: 0.5, 50: 0.5, 75: 0.499}
+        uid_to_block = {100: 1000, 50: 2000, 75: 2001}
+        curr_block = 2001
+        epsilon_func = LinearDecay(0.005, 0.0001, 2000)
+        competitive_uids = pt.validation.compute_competitive_uids(
+            uid_to_average_loss, uid_to_block, epsilon_func
+        )
+        wins, win_rates = pt.validation.compute_wins(
+            competitive_uids,
+            uid_to_average_loss,
+            uid_to_block,
+            epsilon_func,
+            curr_block,
+        )
+        self.assertEqual(wins, {100: 1, 75: 0})
+        self.assertEqual(win_rates, {100: 1.0, 75: 0.0})
+
+        # Verify the case where a new top model submits a few clones.
+        uid_to_average_loss = {100: 0.5, 50: 0.499, 75: 0.499, 80: 0.499}
+        uid_to_block = {100: 1000, 50: 2000, 75: 2001, 80: 2002}
+        curr_block = 2002
+        epsilon_func = LinearDecay(0.005, 0.0001, 2000)
+        competitive_uids = pt.validation.compute_competitive_uids(
+            uid_to_average_loss, uid_to_block, epsilon_func
+        )
+        wins, win_rates = pt.validation.compute_wins(
+            competitive_uids,
+            uid_to_average_loss,
+            uid_to_block,
+            epsilon_func,
+            curr_block,
+        )
+        self.assertEqual(wins, {100: 1, 50: 0})
+        self.assertEqual(win_rates, {100: 1.0, 50: 0.0})


### PR DESCRIPTION
## Changes

- This fix first filters out all models which can't beat all earlier models at full epsilon decay, before computing win rates (and incentive weights). This will ensure that:
        - All clones are filtered out before we compute win rates so clones can no longer provide an artificially high win rate.
        - Any models that is not better than the fully-decayed top model  but submitted at a later block is discarded from the evaluation process.

- Validator version bumped to 3.4.0