### PR TITLE
Use a seed based on sync block for data loading.

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -99,7 +99,12 @@ DATASET_BY_COMPETITION_ID: Dict[CompetitionId, str] = {
     CompetitionId.B14_MODEL: pt.dataset.SubsetFineWebEdu2Loader,
 }
 
-# Defined model constraints by competition id to ensure they are constant across blocks.
+# Synchronize on blocks roughly every 30 minutes.
+SYNC_BLOCK_CADENCE = 150
+# Delay at least as long as the sync block cadence with an additional buffer.
+EVAL_BLOCK_DELAY = SYNC_BLOCK_CADENCE + 100
+
+# Defined model constraints by competition id with decaying epsilon
 MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
     CompetitionId.M772_MODEL: ModelConstraints(
         max_model_parameter_size=772_000_000,
@@ -107,123 +112,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
         sequence_length=1024,
         allowed_architectures=ALLOWED_MODEL_TYPES_1,
         tokenizer="distilgpt2",
-        eval_block_delay=0,
-        epsilon_func=FixedEpsilon(0.005),
-        max_bytes=5 * 1024 * 1024 * 1024,
-    ),
-    CompetitionId.B7_MODEL: ModelConstraints(
-        max_model_parameter_size=6_900_000_000,
-        min_model_parameter_size=6_700_000_000,
-        sequence_length=4096,
-        allowed_architectures=ALLOWED_MODEL_TYPES_2,
-        tokenizer="Xenova/gpt-4",
-        kwargs={
-            "torch_dtype": torch.bfloat16,
-            "attn_implementation": "flash_attention_2",
-        },
-        eval_block_delay=0,
-        epsilon_func=FixedEpsilon(0.005),
-        max_bytes=15 * 1024 * 1024 * 1024,
-    ),
-    CompetitionId.B3_MODEL: ModelConstraints(
-        max_model_parameter_size=3_400_000_000,
-        min_model_parameter_size=3_200_000_000,
-        sequence_length=4096,
-        allowed_architectures=ALLOWED_MODEL_TYPES_2,
-        tokenizer="Xenova/gpt-4",
-        kwargs={
-            "torch_dtype": torch.bfloat16,
-            "attn_implementation": "flash_attention_2",
-        },
-        eval_block_delay=0,
-        epsilon_func=FixedEpsilon(0.005),
-        max_bytes=15 * 1024 * 1024 * 1024,
-    ),
-    CompetitionId.B14_MODEL: ModelConstraints(
-        max_model_parameter_size=13_900_000_000,
-        min_model_parameter_size=13_700_000_000,
-        sequence_length=4096,
-        allowed_architectures=ALLOWED_MODEL_TYPES_2,
-        tokenizer="Xenova/gpt-4",
-        kwargs={
-            "torch_dtype": torch.bfloat16,
-            "attn_implementation": "flash_attention_2",
-        },
-        eval_block_delay=0,
-        epsilon_func=FixedEpsilon(0.005),
-        max_bytes=29 * 1024 * 1024 * 1024,
-    ),
-}
-
-# Defined model constraints by competition id with decaying epsilon
-MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY: Dict[
-    CompetitionId, ModelConstraints
-] = {
-    CompetitionId.M772_MODEL: ModelConstraints(
-        max_model_parameter_size=772_000_000,
-        min_model_parameter_size=572_000_000,
-        sequence_length=1024,
-        allowed_architectures=ALLOWED_MODEL_TYPES_1,
-        tokenizer="distilgpt2",
-        eval_block_delay=0,
-        epsilon_func=LinearDecay(0.005, 0.001, 50400),
-        max_bytes=5 * 1024 * 1024 * 1024,
-    ),
-    CompetitionId.B3_MODEL: ModelConstraints(
-        max_model_parameter_size=3_400_000_000,
-        min_model_parameter_size=3_200_000_000,
-        sequence_length=4096,
-        allowed_architectures=ALLOWED_MODEL_TYPES_2,
-        tokenizer="Xenova/gpt-4",
-        kwargs={
-            "torch_dtype": torch.bfloat16,
-            "attn_implementation": "flash_attention_2",
-        },
-        eval_block_delay=0,
-        epsilon_func=LinearDecay(0.005, 0.001, 50400),
-        max_bytes=15 * 1024 * 1024 * 1024,
-    ),
-    CompetitionId.B7_MODEL: ModelConstraints(
-        max_model_parameter_size=6_900_000_000,
-        min_model_parameter_size=6_700_000_000,
-        sequence_length=4096,
-        allowed_architectures=ALLOWED_MODEL_TYPES_2,
-        tokenizer="Xenova/gpt-4",
-        kwargs={
-            "torch_dtype": torch.bfloat16,
-            "attn_implementation": "flash_attention_2",
-        },
-        eval_block_delay=0,
-        epsilon_func=LinearDecay(0.005, 0.001, 50400),
-        max_bytes=15 * 1024 * 1024 * 1024,
-    ),
-    CompetitionId.B14_MODEL: ModelConstraints(
-        max_model_parameter_size=13_900_000_000,
-        min_model_parameter_size=13_700_000_000,
-        sequence_length=4096,
-        allowed_architectures=ALLOWED_MODEL_TYPES_2,
-        tokenizer="Xenova/gpt-4",
-        kwargs={
-            "torch_dtype": torch.bfloat16,
-            "attn_implementation": "flash_attention_2",
-        },
-        eval_block_delay=0,
-        epsilon_func=LinearDecay(0.005, 0.001, 100800),
-        max_bytes=29 * 1024 * 1024 * 1024,
-    ),
-}
-
-# Defined model constraints by competition id with decaying epsilon
-MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY_2: Dict[
-    CompetitionId, ModelConstraints
-] = {
-    CompetitionId.M772_MODEL: ModelConstraints(
-        max_model_parameter_size=772_000_000,
-        min_model_parameter_size=572_000_000,
-        sequence_length=1024,
-        allowed_architectures=ALLOWED_MODEL_TYPES_1,
-        tokenizer="distilgpt2",
-        eval_block_delay=0,
+        eval_block_delay=EVAL_BLOCK_DELAY,
         epsilon_func=LinearDecay(0.005, 0.0001, 50400),
         max_bytes=5 * 1024 * 1024 * 1024,
     ),
@@ -237,7 +126,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY_2: Dict[
             "torch_dtype": torch.bfloat16,
             "attn_implementation": "flash_attention_2",
         },
-        eval_block_delay=0,
+        eval_block_delay=EVAL_BLOCK_DELAY,
         epsilon_func=LinearDecay(0.005, 0.0001, 50400),
         max_bytes=15 * 1024 * 1024 * 1024,
     ),
@@ -251,42 +140,16 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY_2: Dict[
             "torch_dtype": torch.bfloat16,
             "attn_implementation": "flash_attention_2",
         },
-        eval_block_delay=0,
+        eval_block_delay=EVAL_BLOCK_DELAY,
         epsilon_func=LinearDecay(0.005, 0.0001, 72000),
         max_bytes=29 * 1024 * 1024 * 1024,
     ),
 }
 
-
 # Schedule of competitions by block.
 COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
     (
         0,
-        [
-            Competition(
-                CompetitionId.B7_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MODEL],
-                1.0,
-            )
-        ],
-    ),
-    (
-        3_565_190,
-        [
-            Competition(
-                CompetitionId.M772_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.M772_MODEL],
-                0.35,
-            ),
-            Competition(
-                CompetitionId.B7_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MODEL],
-                0.65,
-            ),
-        ],
-    ),
-    (
-        BLOCK_3B_7BSTAR_UNPACK,
         [
             Competition(
                 CompetitionId.M772_MODEL,
@@ -299,93 +162,8 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
                 0.29,
             ),
             Competition(
-                CompetitionId.B7_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MODEL],
-                0.57,
-            ),
-        ],
-    ),
-    (
-        3_750_683,
-        [
-            Competition(
-                CompetitionId.M772_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY[
-                    CompetitionId.M772_MODEL
-                ],
-                0.14,
-            ),
-            Competition(
-                CompetitionId.B3_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY[
-                    CompetitionId.B3_MODEL
-                ],
-                0.29,
-            ),
-            Competition(
-                CompetitionId.B7_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY[
-                    CompetitionId.B7_MODEL
-                ],
-                0.15,
-            ),
-            Competition(
                 CompetitionId.B14_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY[
-                    CompetitionId.B14_MODEL
-                ],
-                0.42,
-            ),
-        ],
-    ),
-    (
-        3_849_722,
-        [
-            Competition(
-                CompetitionId.M772_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY[
-                    CompetitionId.M772_MODEL
-                ],
-                0.14,
-            ),
-            Competition(
-                CompetitionId.B3_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY[
-                    CompetitionId.B3_MODEL
-                ],
-                0.29,
-            ),
-            Competition(
-                CompetitionId.B14_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY[
-                    CompetitionId.B14_MODEL
-                ],
-                0.57,
-            ),
-        ],
-    ),
-    (
-        BLOCK_SAMPLE_PACK,
-        [
-            Competition(
-                CompetitionId.M772_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY_2[
-                    CompetitionId.M772_MODEL
-                ],
-                0.14,
-            ),
-            Competition(
-                CompetitionId.B3_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY_2[
-                    CompetitionId.B3_MODEL
-                ],
-                0.29,
-            ),
-            Competition(
-                CompetitionId.B14_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY_2[
-                    CompetitionId.B14_MODEL
-                ],
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B14_MODEL],
                 0.57,
             ),
         ],
@@ -427,9 +205,7 @@ batch_size = 1
 sample_min = 5
 # Max number of uids that can be either pending eval or currently being evaluated.
 # We allow the sample_min per competition + 10 additional models to be held at any one time.
-updated_models_limit = (
-    sample_min * len(MODEL_CONSTRAINTS_BY_COMPETITION_ID_LINEAR_DECAY_2) + 10
-)
+updated_models_limit = sample_min * len(MODEL_CONSTRAINTS_BY_COMPETITION_ID) + 10
 # time required between updates to the chain.
 chain_update_cadence = dt.timedelta(minutes=20)
 # Number of blocks required between retrying evaluation of a model.

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -827,7 +827,7 @@ class Validator:
             num_pages=pages_per_eval,
             tokenizer=tokenizer,
             pack_samples=pack_samples,
-            seed=seed,
+            random_seed=seed,
         )
 
         batches = list(dataloader)

--- a/pretrain/dataset.py
+++ b/pretrain/dataset.py
@@ -41,12 +41,17 @@ class SubsetLoader(IterableDataset):
         num_pages=None,
         tokenizer: AutoTokenizer = None,
         pack_samples: bool = False,
+        random_seed: typing.Optional[int] = None,
     ):
         self.batch_size = batch_size
         self.sequence_length = sequence_length
         self.num_pages = num_pages
         self.tokenizer = tokenizer
         self.pack_samples = pack_samples
+
+        # Initialize with seed if provided.
+        if random_seed is not None:
+            random.seed(random_seed)
 
         self.num_rows_per_page = 100
         self.duplicate_page_threshold = 100
@@ -158,9 +163,10 @@ class SubsetFineWebEdu2Loader(SubsetLoader):
         num_pages=None,
         tokenizer: AutoTokenizer = None,
         pack_samples: bool = False,
+        random_seed: typing.Optional[int] = None,
     ):
         super().__init__(
-            batch_size, sequence_length, num_pages, tokenizer, pack_samples
+            batch_size, sequence_length, num_pages, tokenizer, pack_samples, random_seed
         )
 
         # Get the dataset configs and their row sizes
@@ -458,9 +464,10 @@ class SubsetFalconLoader(SubsetLoader):
         num_pages=None,
         tokenizer: AutoTokenizer = None,
         pack_samples: bool = False,
+        random_seed: typing.Optional[int] = None,
     ):
         super().__init__(
-            batch_size, sequence_length, num_pages, tokenizer, pack_samples
+            batch_size, sequence_length, num_pages, tokenizer, pack_samples, random_seed
         )
 
         self.params = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ transformers==4.44.1
 wandb
 datasets
 flash-attn
-taoverse==1.0.6
+taoverse==1.0.8

--- a/scripts/upload_model.py
+++ b/scripts/upload_model.py
@@ -78,7 +78,7 @@ def get_config():
 async def main(config: bt.config):
     # Create bittensor objects.
     bt.logging(config=config)
-    
+
     wallet = bt.wallet(config=config)
     subtensor = bt.subtensor(config=config)
     metagraph = subtensor.metagraph(config.netuid)
@@ -108,7 +108,7 @@ async def main(config: bt.config):
     await pt.mining.push(
         model,
         config.hf_repo_id,
-        wallet,        
+        wallet,
         config.competition_id,
         metadata_store=chain_metadata_store,
     )
@@ -122,4 +122,3 @@ if __name__ == "__main__":
     else:
         print(config)
         asyncio.run(main(config))
-

--- a/tests/pretrain/test_dataset.py
+++ b/tests/pretrain/test_dataset.py
@@ -23,7 +23,7 @@ class TestDataset(unittest.TestCase):
 
         # Load a tokenizer
         tokenizer = pt.model.load_tokenizer(
-            MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MODEL],
+            MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B14_MODEL],
             cache_dir=config.model_dir,
         )
 
@@ -57,7 +57,7 @@ class TestDataset(unittest.TestCase):
 
         # Load a tokenizer
         tokenizer = pt.model.load_tokenizer(
-            MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MODEL],
+            MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B14_MODEL],
             cache_dir=config.model_dir,
         )
 
@@ -98,7 +98,7 @@ class TestDataset(unittest.TestCase):
 
         # Load a tokenizer
         tokenizer = pt.model.load_tokenizer(
-            MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MODEL],
+            MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B14_MODEL],
             cache_dir=config.model_dir,
         )
 
@@ -136,7 +136,7 @@ class TestDataset(unittest.TestCase):
         """Tests that the fineweb loader will only generate page starts that are num rows per pages apart."""
         # Load a tokenizer.
         tokenizer = pt.model.load_tokenizer(
-            MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MODEL],
+            MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B14_MODEL],
             cache_dir=config.model_dir,
         )
 
@@ -182,7 +182,7 @@ class TestDataset(unittest.TestCase):
         """Tests that the fineweb loader correctly applies an initial offset to the page starts."""
         # Load a tokenizer
         tokenizer = pt.model.load_tokenizer(
-            MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MODEL],
+            MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B14_MODEL],
             cache_dir=config.model_dir,
         )
 
@@ -225,3 +225,85 @@ class TestDataset(unittest.TestCase):
             page_starts_2[page_start] += 1
 
         self.assertEqual(set(page_starts_2.keys()), expected_page_starts_2)
+
+    def test_fineweb_loader_seed(self):
+        """Tests that the fineweb data loader fetches the same data with the same seed (barring retries)."""
+
+        # Use the same seed for each loader.
+        RANDOM_SEED = 1
+        # Fetch just two pages to keep the test reasonably fast.
+        NUM_PAGES = 2
+
+        # Load a tokenizer
+        tokenizer = pt.model.load_tokenizer(
+            MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B14_MODEL],
+            cache_dir=config.model_dir,
+        )
+
+        # First dataloader.
+        dataloader_1 = pt.dataset.SubsetFineWebEdu2Loader(
+            batch_size=4,
+            sequence_length=4092,
+            num_pages=NUM_PAGES,
+            tokenizer=tokenizer,
+            random_seed=RANDOM_SEED,
+        )
+
+        # Assert that the number of pages requested were loaded.
+        self.assertEqual(len(dataloader_1.pages), NUM_PAGES)
+
+        # Now create a second loader with the same seed.
+        dataloader_2 = pt.dataset.SubsetFineWebEdu2Loader(
+            batch_size=4,
+            sequence_length=4092,
+            num_pages=NUM_PAGES,
+            tokenizer=tokenizer,
+            random_seed=RANDOM_SEED,
+        )
+
+        # Assert both dataloaders have the same pages
+        self.assertEqual(set(dataloader_1.pages), set(dataloader_2.pages))
+
+        # Assert that both have the same buffers
+        self.assertTrue(np.array_equal(dataloader_1.buffer, dataloader_2.buffer))
+
+    def test_falcon_loader_seed(self):
+        """Tests that the falcon data loader fetches the same data with the same seed."""
+
+        # Use the same seed for each loader.
+        RANDOM_SEED = 1
+        # Fetch just two pages to keep the test reasonably fast.
+        NUM_PAGES = 2
+
+        # Load a tokenizer
+        tokenizer = pt.model.load_tokenizer(
+            MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B14_MODEL],
+            cache_dir=config.model_dir,
+        )
+
+        # First dataloader.
+        dataloader_1 = pt.dataset.SubsetFalconLoader(
+            batch_size=4,
+            sequence_length=4092,
+            num_pages=NUM_PAGES,
+            tokenizer=tokenizer,
+            random_seed=RANDOM_SEED,
+        )
+
+        # Assert that the number of pages requested were loaded.
+        self.assertEqual(len(dataloader_1.pages), NUM_PAGES)
+
+        # Now create a second loader with the same seed.
+        dataloader_2 = pt.dataset.SubsetFalconLoader(
+            batch_size=4,
+            sequence_length=4092,
+            num_pages=NUM_PAGES,
+            tokenizer=tokenizer,
+            random_seed=RANDOM_SEED,
+        )
+
+        # Assert both dataloaders have the same pages
+        self.assertEqual(set(dataloader_1.pages), set(dataloader_2.pages))
+
+        # Assert that both have the same buffers
+        self.assertTrue(np.array_equal(dataloader_1.buffer, dataloader_2.buffer))

--- a/tests/pretrain/test_mining.py
+++ b/tests/pretrain/test_mining.py
@@ -45,7 +45,7 @@ class TestMining(unittest.TestCase):
             pt.mining.push(
                 model=self.tiny_model,
                 wallet=self.wallet,
-                competition_id=CompetitionId.B7_MODEL,
+                competition_id=CompetitionId.B14_MODEL,
                 repo="namespace/name",
                 retry_delay_secs=1,
                 metadata_store=self.metadata_store,


### PR DESCRIPTION
In addition to using the seed, we also need to apply a delay to picking up a model to eval to avoid exploits around training on the exact upcoming dataset.

Since the eval delay applies to the constraints per competition, this pull request also cleans up those definitions in constants to just the most recent one. In doing so it was also discovered that a few places in tests or in mining were using now-deprecated constraints.