### PR TITLE
Add argument to make repo public after model upload.

### DIFF
--- a/docs/miner.md
+++ b/docs/miner.md
@@ -125,6 +125,8 @@ You can manually upload with the following command:
 python scripts/upload_model.py --load_model_dir <path to model> --competition_id 0 --hf_repo_id my-username/my-project --wallet.name coldkey --wallet.hotkey hotkey
 ```
 
+Note: We recommend keeping your hugging face repo private until after you have committed your metadata to the chain. This ensures other miners are unable to upload your model as their own until a later block. Adding the `--update_repo_visibility` flag will also automatically attempt to update the hugging face repo visibility to public after committing to the chain.
+
 Note: If you are not sure about the competition ID, you can add the `--list_competitions` flag to get a list of all competitions. You can also check out competition IDs in [competitions/data.py](https://github.com/macrocosm-os/pretraining/blob/main/competitions/data.py).
 
 ## Running a custom Miner

--- a/pretrain/mining.py
+++ b/pretrain/mining.py
@@ -17,21 +17,13 @@
 # DEALINGS IN THE SOFTWARE.
 
 import os
-import sys
 import time
-import torch
-import constants
+from dataclasses import replace
+from typing import Any, Dict, Optional
 
 import bittensor as bt
 import huggingface_hub
-import pretrain as pt
-
-from dataclasses import replace
-from typing import Optional, Dict, Any
-
-from transformers import PreTrainedModel, AutoModelForCausalLM
 from safetensors.torch import load_model
-
 from taoverse.model import utils as model_utils
 from taoverse.model.data import Model, ModelId
 from taoverse.model.storage.chain.chain_model_metadata_store import (
@@ -43,8 +35,10 @@ from taoverse.model.storage.hugging_face.hugging_face_model_store import (
 from taoverse.model.storage.model_metadata_store import ModelMetadataStore
 from taoverse.model.storage.remote_model_store import RemoteModelStore
 from taoverse.model.utils import get_hash_of_two_strings
+from transformers import AutoModelForCausalLM, PreTrainedModel
 
-
+import constants
+import pretrain as pt
 from competitions.data import CompetitionId
 
 

--- a/scripts/upload_model.py
+++ b/scripts/upload_model.py
@@ -63,6 +63,11 @@ def get_config():
     parser.add_argument(
         "--list_competitions", action="store_true", help="Print out all competitions"
     )
+    parser.add_argument(
+        "--update_repo_visibility",
+        action="store_true",
+        help="If true, the repo will be made public after uploading.",
+    )
 
     # Include wallet and logging arguments from bittensor
     bt.wallet.add_args(parser)
@@ -111,6 +116,7 @@ async def main(config: bt.config):
         wallet,
         config.competition_id,
         metadata_store=chain_metadata_store,
+        update_repo_visibility=config.update_repo_visibility,
     )
 
 

--- a/tests/pretrain/test_mining.py
+++ b/tests/pretrain/test_mining.py
@@ -48,6 +48,7 @@ class TestMining(unittest.TestCase):
                 competition_id=CompetitionId.B14_MODEL,
                 repo="namespace/name",
                 retry_delay_secs=1,
+                update_repo_visibility=False,
                 metadata_store=self.metadata_store,
                 remote_model_store=self.remote_store,
             )


### PR DESCRIPTION
Note this defaults to False as it would be new behavior. Can default to True in the future.

Flag is ```--update_repo_visibility``` which can be passed to the upload_model script.