### PR TITLE
Added support for multi-dataset 14B competition

### DIFF
--- a/competitions/data.py
+++ b/competitions/data.py
@@ -14,6 +14,8 @@ class CompetitionId(IntEnum):
 
     B14_MODEL = 4
 
+    B14_MODEL_MULTI_DATASET = 5
+
     # Overwrite the default __repr__, which doesn't work with
     # bt.logging for some unknown reason.
     def __repr__(self) -> str:

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -105,6 +105,15 @@ DATASET_BY_COMPETITION_ID: Dict[CompetitionId, str] = {
     CompetitionId.B14_MODEL_MULTI_DATASET: pt.dataset.SubsetFalconLoader,
 }
 
+# In a future release we will update the loaders to be able to load a certain number of tokens rather than pages.
+# Until then we can use this ratio to approximate the correct ratio for B14*. Token counts using Xenova/gpt-4.
+ESTIMATED_TOKENS_PER_PAGE_FALCON = 55419
+ESTIMATED_TOKENS_PER_PAGE_FINEWEB = 87490
+# To make the additional data be 1/4 of the total we need a 1:3 ratio.
+PAGE_RATIO_14B_STAR = (
+    0.33 * ESTIMATED_TOKENS_PER_PAGE_FINEWEB / ESTIMATED_TOKENS_PER_PAGE_FALCON
+)
+
 # Synchronize on blocks roughly every 30 minutes.
 SYNC_BLOCK_CADENCE = 150
 # Delay at least as long as the sync block cadence with an additional buffer.

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -64,6 +64,10 @@ BLOCK_3B_7BSTAR_UNPACK = 3_601_190
 # Starting block for activating sample unpacking
 BLOCK_SAMPLE_PACK = 4_001_017
 
+# Starting block for 14B* (multi dataset experiment).
+# TODO: Update starting block as needed.
+BLOCK_14B_STAR = 4_210_361
+
 # Minimum percent of weight on a vali for a miner to be considered a top miner.
 # Since there can be multiple competitions at different reward percentages we can't just check biggest.
 WEIGHT_SYNC_MINER_MIN_PERCENT = 0.05
@@ -97,6 +101,8 @@ DATASET_BY_COMPETITION_ID: Dict[CompetitionId, str] = {
     CompetitionId.B3_MODEL: pt.dataset.SubsetFalconLoader,
     CompetitionId.B7_MODEL: pt.dataset.SubsetFineWebEdu2Loader,
     CompetitionId.B14_MODEL: pt.dataset.SubsetFineWebEdu2Loader,
+    # B14 model multi dataset adds the following dataset to the baseline b14 competition.
+    CompetitionId.B14_MODEL_MULTI_DATASET: pt.dataset.SubsetFalconLoader,
 }
 
 # Synchronize on blocks roughly every 30 minutes.
@@ -165,6 +171,33 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
                 CompetitionId.B14_MODEL,
                 MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B14_MODEL],
                 0.57,
+            ),
+        ],
+    ),
+    (
+        BLOCK_14B_STAR,
+        [
+            # TODO confirm if we are removing the other 2 competitions.
+            Competition(
+                CompetitionId.M772_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.M772_MODEL],
+                0.14,
+            ),
+            Competition(
+                CompetitionId.B3_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B3_MODEL],
+                0.29,
+            ),
+            Competition(
+                CompetitionId.B14_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B14_MODEL],
+                0.52,
+            ),
+            # TODO decide specific weight.
+            Competition(
+                CompetitionId.B14_MODEL_MULTI_DATASET,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B14_MODEL],
+                0.05,
             ),
         ],
     ),

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -65,8 +65,7 @@ BLOCK_3B_7BSTAR_UNPACK = 3_601_190
 BLOCK_SAMPLE_PACK = 4_001_017
 
 # Starting block for 14B* (multi dataset experiment).
-# TODO: Update starting block as needed.
-BLOCK_14B_STAR = 4_210_361
+BLOCK_14B_STAR = 4_252_646
 
 # Minimum percent of weight on a vali for a miner to be considered a top miner.
 # Since there can be multiple competitions at different reward percentages we can't just check biggest.
@@ -186,12 +185,6 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
     (
         BLOCK_14B_STAR,
         [
-            # TODO confirm if we are removing the other 2 competitions.
-            Competition(
-                CompetitionId.M772_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.M772_MODEL],
-                0.14,
-            ),
             Competition(
                 CompetitionId.B3_MODEL,
                 MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B3_MODEL],
@@ -200,7 +193,7 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
             Competition(
                 CompetitionId.B14_MODEL,
                 MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B14_MODEL],
-                0.52,
+                0.66,
             ),
             # TODO decide specific weight.
             Competition(

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -34,10 +34,10 @@ from typing import Dict, List, Tuple
 # ---------------------------------
 
 # Release
-__version__ = "4.5.3"
+__version__ = "4.5.4"
 
 # Validator schema version
-__validator_version__ = "3.4.0"
+__validator_version__ = "4.5.4"
 version_split = __validator_version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -919,7 +919,7 @@ class Validator:
             dataloader_14b_star = SubsetDataLoader_14b_star(
                 batch_size=constants.batch_size,
                 sequence_length=competition_14b_star.constraints.sequence_length,
-                num_pages=pages_per_eval,
+                num_pages=int(pages_per_eval * constants.PAGE_RATIO_14B_STAR),
                 tokenizer=tokenizer,
                 pack_samples=pack_samples,
                 random_seed=seed,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ transformers==4.44.1
 wandb
 datasets
 flash-attn
-taoverse==1.0.8
+taoverse==1.0.9


### PR DESCRIPTION
Adds a new 14B* competition.

This competition takes the existing evaluation from 14B and adds another 33% tokens from falcon as a secondary dataset using the same competition constraints. The usual loss comparison is done on the combined dataset and the winners for 14B* are captured separately.

Note this requires updating taoverse package and also clearing validator state.