### PR TITLE
Set terminal width explicitly.

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1502,4 +1502,11 @@ class Validator:
 
 
 if __name__ == "__main__":
+    # Set an output width explicitly for rich table output (affects the pm2 tables that we use).
+    try:
+        width = os.get_terminal_size().columns
+    except:
+        width = 0
+    os.environ["COLUMNS"] = str(max(200, width))
+
     asyncio.run(Validator().run())


### PR DESCRIPTION
This primarily helps with the pm2 tables that get logged both locally and to the wandb runs.