### PR TITLE
Added the Stack-V2 loader and updated epsilon bounds

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -182,21 +182,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID_2: Dict[CompetitionId, ModelConstraints] = {
             "attn_implementation": "flash_attention_2",
         },
         eval_block_delay=EVAL_BLOCK_DELAY,
-        epsilon_func=LinearDecay(0.003, 0.0001, 36000),
-        max_bytes=29 * 1024 * 1024 * 1024,
-    ),
-    CompetitionId.B14_MODEL_MULTI_DATASET: ModelConstraints(
-        max_model_parameter_size=13_900_000_000,
-        min_model_parameter_size=13_700_000_000,
-        sequence_length=4096,
-        allowed_architectures=ALLOWED_MODEL_TYPES_2,
-        tokenizer="Xenova/gpt-4",
-        kwargs={
-            "torch_dtype": torch.bfloat16,
-            "attn_implementation": "flash_attention_2",
-        },
-        eval_block_delay=EVAL_BLOCK_DELAY,
-        epsilon_func=LinearDecay(0.005, 0.0003, 50400),
+        epsilon_func=LinearDecay(0.005, 0.0001, 50400),
         max_bytes=29 * 1024 * 1024 * 1024,
     ),
 
@@ -239,7 +225,7 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
             ),
             Competition(
                 CompetitionId.B14_MODEL_MULTI_DATASET,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID_2[CompetitionId.B14_MODEL_MULTI_DATASET],
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID_2[CompetitionId.B14_MODEL],
                 0.36,
             ),
         ],

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -269,9 +269,6 @@ alpha = 0.5
 # 0.01 gives ~96% to best model with only ~3 receiving any weights.
 temperature = 0.01
 
-# block to activate sample packing
-sample_pack_block = BLOCK_SAMPLE_PACK
-
 # validators number of pages to eval over miners on each step.
 pages_per_eval_unpack = 10  # With sample unpacking
 pages_per_eval_pack = 22

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -262,7 +262,7 @@ pages_per_eval_pack = 22
 # In a future release we will update the loaders to be able to load a certain number of tokens rather than pages.
 # Until then we need to set this manually
 pages_per_eval_stack_v1_dedup = 1
-pages_per_eval_stack_v2_dedup = 10
+pages_per_eval_stack_v2_dedup = 9
 
 # validator eval batch size.
 batch_size = 1

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -855,7 +855,11 @@ class Validator:
         bt.logging.trace(f"Current block: {cur_block}")
 
         # Get the dataloader for this competition
-        SubsetDataLoader = constants.DATASET_BY_COMPETITION_ID[competition.id]
+
+        if cur_block < constants.BLOCK_STACK_V2_DEDUP:
+            SubsetDataLoader = constants.DATASET_BY_COMPETITION_ID[competition.id]
+        else:
+            SubsetDataLoader = constants.DATASET_BY_COMPETITION_ID_2[competition.id]
         bt.logging.trace(f"Dataset in use: {SubsetDataLoader.name}.")
 
         if running_14b_star:
@@ -910,10 +914,16 @@ class Validator:
         bt.logging.debug(f"Pages used are {pages}")
 
         if running_14b_star:
+
+            if cur_block < constants.BLOCK_STACK_V2_DEDUP:
+                num_pages_code_dataset = constants.pages_per_eval_stack_v1_dedup
+            else:
+                num_pages_code_dataset = constants.pages_per_eval_stack_v2_dedup
+
             dataloader_14b_star = SubsetDataLoader_14b_star(
                 batch_size=constants.batch_size,
                 sequence_length=competition_14b_star.constraints.sequence_length,
-                num_pages=constants.pages_per_eval_14bstar_pack,
+                num_pages=num_pages_code_dataset
                 tokenizer=tokenizer,
                 pack_samples=pack_samples,
                 random_seed=seed,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -854,12 +854,16 @@ class Validator:
 
         bt.logging.trace(f"Current block: {cur_block}")
 
-        # Get the dataloader for this competition
+
 
         if cur_block < constants.BLOCK_STACK_V2_DEDUP:
-            SubsetDataLoader = constants.DATASET_BY_COMPETITION_ID[competition.id]
+            dataset_by_competition_id = constants.DATASET_BY_COMPETITION_ID
         else:
-            SubsetDataLoader = constants.DATASET_BY_COMPETITION_ID_2[competition.id]
+            dataset_by_competition_id = constants.DATASET_BY_COMPETITION_ID_2
+
+        # Get the dataloader for this competition
+        SubsetDataLoader = dataset_by_competition_id[competition.id]
+
         bt.logging.trace(f"Dataset in use: {SubsetDataLoader.name}.")
 
         if running_14b_star:
@@ -867,7 +871,7 @@ class Validator:
             uid_to_state_14b_star = defaultdict(PerUIDEvalState)
 
             # Also get the dataloader for 14b_star.
-            SubsetDataLoader_14b_star = constants.DATASET_BY_COMPETITION_ID[
+            SubsetDataLoader_14b_star = dataset_by_competition_id[
                 CompetitionId.B14_MODEL_MULTI_DATASET
             ]
             bt.logging.trace(

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -923,7 +923,7 @@ class Validator:
             dataloader_14b_star = SubsetDataLoader_14b_star(
                 batch_size=constants.batch_size,
                 sequence_length=competition_14b_star.constraints.sequence_length,
-                num_pages=num_pages_code_dataset
+                num_pages=num_pages_code_dataset,
                 tokenizer=tokenizer,
                 pack_samples=pack_samples,
                 random_seed=seed,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ transformers==4.44.1
 wandb
 datasets
 flash-attn
+smart-open==7.0.5
 taoverse==1.0.9


### PR DESCRIPTION
- Added activation block for using `The Stack v2-dedup` instead of `The Stack v1-dedup`.
- Added activation blocks for updating epsilon decay bounds (0.003 -> 0.0001 : 3 days for 3B), (0.005 -> 0.0001: 5 days for 14(*))
- Percentage of code tokens for the 14B* competition is set to ~15% on average
- Bumped version to 4.6.2
