### PR TITLE
Added s3 extra to smart-open install requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ transformers==4.44.1
 wandb==0.18.3
 datasets==3.0.1
 flash-attn==2.6.3
-smart-open==7.0.5
+smart-open[s3]==7.0.5
 taoverse==1.0.9


### PR DESCRIPTION
Use `smart-open[s3]` instead of `smart-open` in requirements