### PR TITLE
Fixed model pushing

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -32,7 +32,7 @@ from pretrain.eval.method import EvalMethodId
 # ---------------------------------
 
 # Release
-__version__ = "5.1.0"
+__version__ = "5.1.1"
 
 # Validator schema version
 __validator_version__ = "4.6.0"

--- a/pretrain/graph.py
+++ b/pretrain/graph.py
@@ -58,7 +58,7 @@ def best_uid(
 
     for _, miner_uid in top_miners:
         metadata = asyncio.run(
-            metadata_store.retrieve_model_metadata(metagraph.hotkeys[miner_uid])
+            metadata_store.retrieve_model_metadata(miner_uid, metagraph.hotkeys[miner_uid])
         )
         if metadata and metadata.id.competition_id == competition_id:
             return miner_uid

--- a/pretrain/mining.py
+++ b/pretrain/mining.py
@@ -75,9 +75,12 @@ async def push(
     """
     logging.info("Pushing model")
 
+    subtensor = bt.subtensor()
+    subnet_uid = constants.SUBNET_UID
+
     if metadata_store is None:
         metadata_store = ChainModelMetadataStore(
-            subtensor=bt.subtensor(), subnet_uid=constants.SUBNET_UID, wallet=wallet
+            subtensor=subtensor, subnet_uid=subnet_uid, wallet=wallet
         )
 
     if remote_model_store is None:
@@ -117,8 +120,14 @@ async def push(
                 "Wrote model metadata to the chain. Checking we can read it back..."
             )
 
+            logging.debug(
+                "Retrieving model's UID..."
+            )
+
+            uid = subtensor.get_uid_for_hotkey_on_subnet(wallet.hotkey.ss58_address, subnet_uid)
+
             model_metadata = await metadata_store.retrieve_model_metadata(
-                wallet.hotkey.ss58_address
+                uid, wallet.hotkey.ss58_address
             )
 
             if (
@@ -175,7 +184,7 @@ async def get_repo(
         metagraph = bt.metagraph(netuid=constants.SUBNET_UID)
 
     hotkey = metagraph.hotkeys[uid]
-    model_metadata = await metadata_store.retrieve_model_metadata(hotkey)
+    model_metadata = await metadata_store.retrieve_model_metadata(uid, hotkey)
 
     if not model_metadata:
         raise ValueError(f"No model metadata found for miner {uid}")
@@ -229,7 +238,7 @@ async def load_remote_model(
         remote_model_store = HuggingFaceModelStore()
 
     hotkey = metagraph.hotkeys[uid]
-    model_metadata = await metadata_store.retrieve_model_metadata(hotkey)
+    model_metadata = await metadata_store.retrieve_model_metadata(uid, hotkey)
     if not model_metadata:
         raise ValueError(f"No model metadata found for miner {uid}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ wandb==0.18.3
 datasets==3.0.1
 flash-attn==2.6.3
 smart-open[s3]==7.0.5
-taoverse==1.4.0
+taoverse==1.4.1


### PR DESCRIPTION
the `uid` argument has been missing from some calls to `retrieve_model_metadata` across the codebase. Now fixed!