### PR TITLE
Hotfix/handle failed dataloading

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -185,7 +185,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
         allowed_architectures=ALLOWED_MODEL_TYPES_TTS,
         tokenizer="e2tts",
         eval_block_delay=EVAL_BLOCK_DELAY,
-        epsilon_func=LinearDecay(0.005, 0.0005, 7200 * 7),
+        epsilon_func=LinearDecay(0.005, 0.0005, 7200 * 10),
         max_bytes=2 * 1024 * 1024 * 1024,
     ),
 
@@ -209,7 +209,18 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
                             "batch_size": BATCH_SIZE,
                             "num_pages": PAGES_PER_EVAL_FINEWEB,
                         },
-                        weight=0.55,
+                        weight=0.30,
+                    ),
+                    EvalTask(
+                        name="FINEWEB_EDU2",
+                        method_id=EvalMethodId.TEXT_LOSS,
+                        dataset_id=DatasetId.FINEWEB2,
+                        normalization_id=NormalizationId.NONE,
+                        dataset_kwargs={
+                            "batch_size": BATCH_SIZE,
+                            "num_pages": PAGES_PER_EVAL_FINEWEB2,
+                        },
+                        weight=0.25,
                     ),
                     EvalTask(
                         name="STACKV2_DEDUP",
@@ -271,7 +282,18 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
                             "batch_size": BATCH_SIZE,
                             "num_pages": PAGES_PER_EVAL_FINEWEB,
                         },
-                        weight=0.55,
+                        weight=0.3,
+                    ),
+                    EvalTask(
+                        name="FINEWEB_EDU2",
+                        method_id=EvalMethodId.TEXT_LOSS,
+                        dataset_id=DatasetId.FINEWEB2,
+                        normalization_id=NormalizationId.NONE,
+                        dataset_kwargs={
+                            "batch_size": BATCH_SIZE,
+                            "num_pages": PAGES_PER_EVAL_FINEWEB2,
+                        },
+                        weight=0.25,
                     ),
                     EvalTask(
                         name="STACKV2_DEDUP",
@@ -360,7 +382,18 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
                             "batch_size": BATCH_SIZE,
                             "num_pages": PAGES_PER_EVAL_FINEWEB,
                         },
-                        weight=0.55,
+                        weight=0.3,
+                    ),
+                    EvalTask(
+                        name="FINEWEB_EDU2",
+                        method_id=EvalMethodId.TEXT_LOSS,
+                        dataset_id=DatasetId.FINEWEB2,
+                        normalization_id=NormalizationId.NONE,
+                        dataset_kwargs={
+                            "batch_size": BATCH_SIZE,
+                            "num_pages": PAGES_PER_EVAL_FINEWEB2,
+                        },
+                        weight=0.25,
                     ),
                     EvalTask(
                         name="STACKV2_DEDUP",
@@ -422,7 +455,18 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
                             "batch_size": BATCH_SIZE,
                             "num_pages": PAGES_PER_EVAL_FINEWEB,
                         },
-                        weight=0.55,
+                        weight=0.3,
+                    ),
+                    EvalTask(
+                        name="FINEWEB_EDU2",
+                        method_id=EvalMethodId.TEXT_LOSS,
+                        dataset_id=DatasetId.FINEWEB2,
+                        normalization_id=NormalizationId.NONE,
+                        dataset_kwargs={
+                            "batch_size": BATCH_SIZE,
+                            "num_pages": PAGES_PER_EVAL_FINEWEB2,
+                        },
+                        weight=0.25,
                     ),
                     EvalTask(
                         name="STACKV2_DEDUP",

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -34,10 +34,10 @@ from pretrain.eval.method import EvalMethodId
 # ---------------------------------
 
 # Release
-__version__ = "6.0.1"
+__version__ = "6.0.2"
 
 # Validator schema version
-__validator_version__ = "4.6.1"
+__validator_version__ = "4.6.2"
 version_split = __validator_version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -59,7 +59,7 @@ BLOCK_TTS = 5_177_981
 
 # Minimum stake to consider a validator when checking for miners with weights.
 # This corresponded to top-10 validator on july 31st, 2024
-WEIGHT_SYNC_VALI_MIN_STAKE = 200_000
+WEIGHT_SYNC_VALI_MIN_STAKE = 50_000
 
 # Minimum percent of weight on a vali for a miner to be considered a top miner.
 # Since there can be multiple competitions at different reward percentages we can't just check biggest.

--- a/pretrain/dataset.py
+++ b/pretrain/dataset.py
@@ -61,7 +61,7 @@ class SubsetLoader(IterableDataset):
 
         self.num_rows_per_page = 50
         self.duplicate_page_threshold = 100
-        self.retry_limit = 10
+        self.retry_limit = 15
         self.retry_delay = 5
 
         # Buffers
@@ -401,9 +401,11 @@ class SubsetFineWebEdu2Loader(SubsetLoader):
             except requests.exceptions.RequestException as e:
                 attempts += 1
                 logging.warning(
-                    f"Failed to fetch data, retrying. Attempt {attempts}/{self.retry_limit * num_pages}"
+                    f"Failed to fetch data, retrying. Attempt {attempts}/{self.retry_limit}"
                 )
-                if attempts >= num_pages * self.retry_limit:
+                if attempts < self.retry_limit:
+                    time.sleep(self.retry_delay)
+                else:
                     logging.error("Maximum retry limit reached. Unable to fetch data.")
                     raise
 
@@ -470,9 +472,11 @@ class SubsetFineWebEdu2Loader(SubsetLoader):
                 attempts += 1
                 logging.warning(
                     f"Failed to fetch data, retrying with a newly sampled page. "
-                    f"Attempt {attempts}/{self.retry_limit * num_pages}"
+                    f"Attempt {attempts}/{self.retry_limit}"
                 )
-                if attempts >= num_pages * self.retry_limit:
+                if attempts < self.retry_limit:
+                    time.sleep(self.retry_delay)
+                else:
                     logging.error("Maximum retry limit reached. Unable to fetch data.")
                     raise
 
@@ -528,7 +532,7 @@ class SubsetPeopleSpeechLoader(SubsetFineWebEdu2Loader):
 
         self.num_rows_per_page = 40
         self.duplicate_page_threshold = 100
-        self.retry_limit = 10
+        self.retry_limit = 15
         self.retry_delay = 5
 
         # Buffers

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ wandb==0.18.3
 datasets==3.0.1
 flash-attn==2.6.3
 smart-open[s3]==7.0.5
-taoverse==2.0.0
+taoverse==2.0.1
 pydub==0.25.1
 vocos==0.1.0
 jiwer==3.1.0


### PR DESCRIPTION
## Changes
- Skip eval tasks upon failed data loading.
- Renormalize eval task weights in case of failure
- Reduce number of attempts upon failed page loading in dataset loader. Sleep between attemps.
- Increase epsilon decay to 10 days for the TTS competition.
- Loader for FineWeb-Edu2 is back in both 3B and 14B competitions.
- Reduce min vali stake from 200K to 50K for top miners selection
- Bump taoverse dependency to 2.0.1.